### PR TITLE
feat: add conformal guard and kelly policy

### DIFF
--- a/engine/config/backtest.yaml
+++ b/engine/config/backtest.yaml
@@ -4,4 +4,12 @@ rolling:
   window_giornate: 8
   step: 1
 folds: 3
-policy: hold
+policy:
+  mode: "conformal-kelly"
+  alpha: 0.1
+  mondrian_keys: ["Div", "OverroundBin"]
+  window: 10
+  edge_thr: 0.02
+  kelly_cap: 0.15
+  max_width: 0.35
+  variance_penalty: 0.0

--- a/engine/config/model.yaml
+++ b/engine/config/model.yaml
@@ -30,3 +30,9 @@ meta_learner:
     n_estimators: 500
     min_data_in_leaf: 50
   calibrate: true
+
+conformal:
+  alpha: 0.1
+  mondrian_keys: []
+  min_group_size: 100
+  width_cap: 0.6

--- a/engine/eval/backtester.py
+++ b/engine/eval/backtester.py
@@ -1,15 +1,96 @@
 """Backtesting utilities for betting strategies."""
 from __future__ import annotations
 
+from typing import List
+
 import hydra
+import numpy as np
+import pandas as pd
 from omegaconf import DictConfig
+
+from ..risk.conformal import ConformalIntervalPredictor, MondrianIndexer
+from ..risk.thresholds import conformal_kelly, lower_edge_rule
+from .metrics import average_width, empirical_coverage, validity_gap
+
+
+def apply_conformal_guard(df: pd.DataFrame, cfg: DictConfig) -> pd.DataFrame:
+    """Apply conformal intervals and betting policy to ``df``.
+
+    Parameters
+    ----------
+    df: DataFrame
+        Must contain probability columns ``pH``, ``pD``, ``pA`` and odds ``oH``, ``oD``, ``oA``.
+    cfg: DictConfig
+        Configuration with ``conformal`` and ``policy`` sections.
+    """
+
+    p_cols = ["pH", "pD", "pA"]
+    odds_cols = ["oH", "oD", "oA"]
+
+    mondrian = MondrianIndexer(cfg.conformal.mondrian_keys)
+    predictor = ConformalIntervalPredictor(
+        cfg.conformal.alpha,
+        mondrian,
+        cfg.conformal.min_group_size,
+        cfg.conformal.width_cap,
+    )
+
+    predictor.fit(df, p_cols, "y")
+    intervals = predictor.predict(df, p_cols)
+    df[[c + "_low" for c in p_cols]] = intervals["p_low"]
+    df[[c + "_high" for c in p_cols]] = intervals["p_high"]
+
+    best = df[p_cols].to_numpy().argmax(axis=1)
+    odds = df[odds_cols].to_numpy()
+    p_low = intervals["p_low"][np.arange(len(df)), best]
+    p_high = intervals["p_high"][np.arange(len(df)), best]
+    width = p_high - p_low
+    edge_low = p_low * odds[np.arange(len(df)), best] - 1
+
+    stakes: List[float] = []
+    for i in range(len(df)):
+        if lower_edge_rule(p_low[i], odds[i, best[i]], cfg.policy.edge_thr) and width[i] <= cfg.policy.max_width:
+            stake = conformal_kelly(
+                p_low[i],
+                odds[i, best[i]],
+                cfg.policy.kelly_cap,
+                cfg.policy.variance_penalty,
+                width[i],
+            )
+        else:
+            stake = 0.0
+        stakes.append(stake)
+
+    df["stake"] = stakes
+    df["edge_low"] = edge_low
+    df["sel_cls"] = best
+
+    return df
 
 
 @hydra.main(config_path="../config", config_name="config", version_base=None)
-def main(cfg: DictConfig) -> None:  # pragma: no cover - placeholder
+def main(cfg: DictConfig) -> None:  # pragma: no cover - demonstration
     """Entry point for the backtester CLI."""
-    print("Backtester running with config:")
-    print(cfg)
+
+    df = pd.DataFrame(
+        {
+            "pH": [0.4, 0.35],
+            "pD": [0.3, 0.3],
+            "pA": [0.3, 0.35],
+            "oH": [2.1, 2.2],
+            "oD": [3.1, 3.0],
+            "oA": [3.2, 3.4],
+            "y": [0, 1],
+        }
+    )
+    df = apply_conformal_guard(df, cfg)
+    cov = empirical_coverage(
+        df[["pH_low", "pD_low", "pA_low"]].to_numpy(),
+        df[["pH_high", "pD_high", "pA_high"]].to_numpy(),
+        df["y"].to_numpy(),
+    )
+    print("coverage", cov)
+    print(df)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/engine/eval/metrics.py
+++ b/engine/eval/metrics.py
@@ -1,0 +1,23 @@
+"""Evaluation metrics for conformal prediction."""
+from __future__ import annotations
+
+import numpy as np
+
+
+def empirical_coverage(p_low: np.ndarray, p_high: np.ndarray, y_true: np.ndarray) -> float:
+    """Empirical coverage of the lower-bound argmax strategy."""
+
+    pred = p_low.argmax(axis=1)
+    return float((pred == y_true).mean())
+
+
+def average_width(p_low: np.ndarray, p_high: np.ndarray) -> float:
+    """Average interval width across classes."""
+
+    return float(np.mean((p_high - p_low).mean(axis=1)))
+
+
+def validity_gap(coverage: float, alpha: float) -> float:
+    """Absolute gap between empirical and target coverage."""
+
+    return abs(coverage - (1 - alpha))

--- a/engine/eval/schemas.py
+++ b/engine/eval/schemas.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 import pandera as pa
 from pandera import Column, DataFrameSchema, Check
 
-__all__ = ["dc_states_schema", "dc_preds_schema", "ensemble_preds_schema"]
+__all__ = [
+    "dc_states_schema",
+    "dc_preds_schema",
+    "ensemble_preds_schema",
+    "conformal_calibs_schema",
+    "bet_logs_conformal_schema",
+]
 
 
 dc_states_schema = DataFrameSchema(
@@ -50,6 +56,38 @@ ensemble_preds_schema = DataFrameSchema(
         "pd": Column(pa.Float64, Check.in_range(0, 1, inclusive="both")),
         "pa": Column(pa.Float64, Check.in_range(0, 1, inclusive="both")),
         "method": Column(pa.String),
+        "created_at": Column(pa.DateTime),
+    },
+    coerce=True,
+)
+
+
+conformal_calibs_schema = DataFrameSchema(
+    {
+        "mondrian_key": Column(pa.String),
+        "fold": Column(pa.Int64),
+        "cls": Column(pa.String),
+        "alpha": Column(pa.Float64),
+        "coverage": Column(pa.Float64),
+        "width_avg": Column(pa.Float64),
+        "fitted_at": Column(pa.DateTime),
+    },
+    coerce=True,
+)
+
+
+bet_logs_conformal_schema = DataFrameSchema(
+    {
+        "match_id": Column(pa.String),
+        "t": Column(pa.Int64),
+        "sel_cls": Column(pa.String),
+        "odds": Column(pa.Float64),
+        "p_low": Column(pa.Float64),
+        "p_hat": Column(pa.Float64),
+        "edge_low": Column(pa.Float64),
+        "stake": Column(pa.Float64),
+        "pnl": Column(pa.Float64),
+        "params": Column(pa.String),
         "created_at": Column(pa.DateTime),
     },
     coerce=True,

--- a/engine/risk/__init__.py
+++ b/engine/risk/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .conformal import (
+    ConformalIntervalPredictor,
+    MondrianIndexer,
+    VennAbersCalibrator,
+)
+from .thresholds import conformal_kelly, lower_edge_rule
+
+__all__ = [
+    "VennAbersCalibrator",
+    "MondrianIndexer",
+    "ConformalIntervalPredictor",
+    "lower_edge_rule",
+    "conformal_kelly",
+]

--- a/engine/risk/conformal.py
+++ b/engine/risk/conformal.py
@@ -1,7 +1,151 @@
-"""Conformal prediction utilities for classification and regression."""
+"""Conformal prediction utilities for probability intervals."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Dict, Iterable, Iterator
 
-def conformal_interval():  # pragma: no cover - placeholder
-    """Compute conformal prediction intervals."""
-    raise NotImplementedError
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class VennAbersCalibrator:
+    """Simple split-conformal calibrator for multiclass probabilities."""
+
+    alpha: float = 0.1
+    q_: np.ndarray | None = None
+
+    def fit(self, p_hat: np.ndarray, y: np.ndarray) -> "VennAbersCalibrator":
+        """Fit nonconformity scores and quantiles.
+
+        Parameters
+        ----------
+        p_hat: array-like of shape (n_samples, n_classes)
+            Raw probability estimates from a classifier.
+        y: array-like of shape (n_samples,)
+            True class labels encoded as integers ``[0, n_classes)``.
+        """
+
+        n_classes = p_hat.shape[1]
+        self.q_ = np.zeros(n_classes)
+        for c in range(n_classes):
+            y_bin = (y == c).astype(float)
+            scores = np.abs(y_bin - p_hat[:, c])
+            # (1 - alpha) quantile of nonconformity scores
+            self.q_[c] = np.quantile(scores, 1 - self.alpha)
+        return self
+
+    def predict_interval(self, p_hat: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Predict probability intervals for each class.
+
+        Parameters
+        ----------
+        p_hat: array-like of shape (n_samples, n_classes)
+            Raw probability estimates for which to compute intervals.
+        """
+
+        if self.q_ is None:
+            raise ValueError("Calibrator must be fitted before prediction")
+
+        p_low = np.clip(p_hat - self.q_, 0.0, 1.0)
+        p_high = np.clip(p_hat + self.q_, 0.0, 1.0)
+        return p_low, p_high
+
+
+class MondrianIndexer:
+    """Utility to build Mondrian partitioning keys."""
+
+    def __init__(self, keys: Iterable[str] | None = None):
+        self.keys = list(keys or [])
+
+    def make_keys(self, df_matches: pd.DataFrame) -> np.ndarray:
+        """Return array of Mondrian keys for ``df_matches``."""
+
+        if not self.keys:
+            return np.array(["global"] * len(df_matches))
+
+        df = df_matches.copy()
+        for key in self.keys:
+            if key == "OverroundBin":
+                if "overround" not in df.columns:
+                    raise KeyError("'overround' column required for OverroundBin")
+                df[key] = pd.qcut(df["overround"], 10, labels=False, duplicates="drop")
+            else:
+                if key not in df.columns:
+                    raise KeyError(f"Missing column '{key}' for Mondrian index")
+        parts = [df[k].astype(str) for k in self.keys]
+        combo = parts[0]
+        for part in parts[1:]:
+            combo = combo.str.cat(part, sep="|")
+        return combo.to_numpy()
+
+    def groups(self, df_matches: pd.DataFrame) -> Iterator[tuple[str, np.ndarray]]:
+        """Yield ``(key, mask)`` pairs for each Mondrian group."""
+
+        keys = self.make_keys(df_matches)
+        for key in np.unique(keys):
+            mask = keys == key
+            yield key, mask
+
+
+class ConformalIntervalPredictor:
+    """Wrapper handling Mondrian partitioning and interval prediction."""
+
+    def __init__(
+        self,
+        alpha: float,
+        mondrian: MondrianIndexer | None = None,
+        min_group_size: int = 100,
+        width_cap: float = 0.6,
+    ) -> None:
+        self.alpha = alpha
+        self.mondrian = mondrian or MondrianIndexer([])
+        self.min_group_size = min_group_size
+        self.width_cap = width_cap
+        self.calibrators: Dict[str, VennAbersCalibrator] = {}
+        self.global_calibrator: VennAbersCalibrator | None = None
+
+    def fit(
+        self, df_calib: pd.DataFrame, p_hat_cols: list[str], y_col: str
+    ) -> "ConformalIntervalPredictor":
+        """Fit calibrators for each Mondrian group."""
+
+        p_hat = df_calib[p_hat_cols].to_numpy()
+        y = df_calib[y_col].to_numpy()
+        keys = self.mondrian.make_keys(df_calib)
+
+        self.global_calibrator = VennAbersCalibrator(self.alpha).fit(p_hat, y)
+
+        for key in np.unique(keys):
+            mask = keys == key
+            if mask.sum() < self.min_group_size:
+                continue
+            cal = VennAbersCalibrator(self.alpha).fit(p_hat[mask], y[mask])
+            self.calibrators[key] = cal
+        return self
+
+    def _get_calibrator(self, key: str) -> VennAbersCalibrator:
+        if self.global_calibrator is None:
+            raise ValueError("Predictor not fitted")
+        return self.calibrators.get(key, self.global_calibrator)
+
+    def predict(
+        self, df_test: pd.DataFrame, p_hat_cols: list[str]
+    ) -> dict[str, np.ndarray]:
+        """Predict probability intervals for ``df_test``."""
+
+        p_hat = df_test[p_hat_cols].to_numpy()
+        keys = self.mondrian.make_keys(df_test)
+        n = len(df_test)
+        n_classes = p_hat.shape[1]
+        p_low = np.zeros((n, n_classes))
+        p_high = np.zeros((n, n_classes))
+        for key in np.unique(keys):
+            mask = keys == key
+            cal = self._get_calibrator(key)
+            lo, hi = cal.predict_interval(p_hat[mask])
+            width = np.clip(hi - lo, 0.0, self.width_cap)
+            hi = np.clip(lo + width, 0.0, 1.0)
+            p_low[mask] = lo
+            p_high[mask] = hi
+        return {"p_low": p_low, "p_high": p_high}

--- a/engine/risk/thresholds.py
+++ b/engine/risk/thresholds.py
@@ -1,0 +1,42 @@
+"""Thresholding and bet sizing helpers for conformal strategies."""
+from __future__ import annotations
+
+
+def lower_edge_rule(p_low: float, odds: float, edge_thr: float) -> bool:
+    """Return True if the lower-bound edge exceeds ``edge_thr``."""
+
+    return p_low * odds - 1 >= edge_thr
+
+
+def conformal_kelly(
+    p_low: float,
+    odds: float,
+    kelly_cap: float,
+    variance_penalty: float,
+    width: float,
+) -> float:
+    """Kelly sizing using the lower-bound probability.
+
+    Parameters
+    ----------
+    p_low: float
+        Lower-bound probability for the selected outcome.
+    odds: float
+        Decimal odds for the outcome.
+    kelly_cap: float
+        Maximum fraction of bankroll to wager.
+    variance_penalty: float
+        Multiplier applied to penalise wide intervals.
+    width: float
+        Interval width for the selected class.
+    """
+
+    # Standard Kelly criterion
+    edge = odds * p_low - 1
+    if edge <= 0:
+        return 0.0
+    kelly = edge / (odds - 1)
+    # Variance penalty
+    kelly *= max(0.0, 1 - variance_penalty * width)
+    # Cap
+    return max(0.0, min(kelly, kelly_cap))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure package root is on sys.path for all tests
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/test_conformal.py
+++ b/tests/test_conformal.py
@@ -1,0 +1,65 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# Ensure package root on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from engine.risk.conformal import ConformalIntervalPredictor, MondrianIndexer
+from engine.risk.thresholds import conformal_kelly
+from engine.eval.metrics import empirical_coverage
+
+
+def test_venn_abers_calibrator_coverage():
+    np.random.seed(0)
+    n_calib, n_test = 600, 300
+    true_probs = np.random.dirichlet([3, 3, 3], size=n_calib + n_test)
+    y = np.array([np.random.choice(3, p=p) for p in true_probs])
+    p_hat = true_probs + np.random.normal(0, 0.05, size=true_probs.shape)
+    p_hat = np.clip(p_hat, 0, 1)
+    p_hat /= p_hat.sum(axis=1, keepdims=True)
+
+    calib_df = pd.DataFrame(p_hat[:n_calib], columns=["pH", "pD", "pA"])
+    calib_df["y"] = y[:n_calib]
+    test_df = pd.DataFrame(p_hat[n_calib:], columns=["pH", "pD", "pA"])
+    y_test = y[n_calib:]
+
+    cip = ConformalIntervalPredictor(0.1, MondrianIndexer([]), min_group_size=50)
+    cip.fit(calib_df, ["pH", "pD", "pA"], "y")
+    intervals = cip.predict(test_df, ["pH", "pD", "pA"])
+    true_p = true_probs[n_calib:]
+    inside = []
+    for i in range(len(test_df)):
+        c = y_test[i]
+        inside.append(
+            intervals["p_low"][i, c] <= true_p[i, c] <= intervals["p_high"][i, c]
+        )
+    cov = np.mean(inside)
+    assert abs(cov - 0.9) < 0.1
+
+
+def test_conformal_interval_predictor_fallback():
+    df = pd.DataFrame(
+        {
+            "Div": ["A", "B", "A", "B"],
+            "overround": [0.1, 0.2, 0.15, 0.18],
+            "pH": [0.3, 0.4, 0.5, 0.6],
+            "pD": [0.3, 0.3, 0.2, 0.2],
+            "pA": [0.4, 0.3, 0.3, 0.2],
+            "y": [0, 1, 2, 0],
+        }
+    )
+    cip = ConformalIntervalPredictor(0.1, MondrianIndexer(["OverroundBin"]), min_group_size=10)
+    cip.fit(df, ["pH", "pD", "pA"], "y")
+    preds = cip.predict(df, ["pH", "pD", "pA"])
+    assert preds["p_low"].shape == (4, 3)
+
+
+def test_conformal_kelly_cap_and_penalty():
+    stake = conformal_kelly(0.6, 2.0, kelly_cap=0.15, variance_penalty=0.5, width=0.2)
+    assert stake == 0.15
+    stake2 = conformal_kelly(0.6, 2.0, kelly_cap=1.0, variance_penalty=0.0, width=0.2)
+    stake3 = conformal_kelly(0.6, 2.0, kelly_cap=1.0, variance_penalty=1.0, width=0.2)
+    assert stake2 > stake3

--- a/ui/pages/04_📈_Backtest.py
+++ b/ui/pages/04_📈_Backtest.py
@@ -1,0 +1,22 @@
+"""Streamlit backtest page with conformal guard controls."""
+import streamlit as st
+
+st.title("📈 Backtest")
+
+enable = st.checkbox("Enable Conformal Guard", value=False)
+if enable:
+    alpha = st.slider("Alpha", 0.01, 0.5, 0.1)
+    mondrian = st.multiselect(
+        "Mondrian keys",
+        ["Div", "Season", "Month", "OverroundBin", "RegimeId"],
+        default=["Div"],
+    )
+    window = st.number_input("Calibration window", min_value=1, max_value=50, value=10)
+    edge_thr = st.number_input("Edge threshold", 0.0, 1.0, 0.02)
+    kelly_cap = st.number_input("Kelly cap", 0.0, 1.0, 0.15)
+    max_width = st.number_input("Max width", 0.0, 1.0, 0.35)
+    st.write(
+        f"Conformal guard enabled with α={alpha}, keys={mondrian}, window={window}, edge≥{edge_thr}"
+    )
+else:
+    st.write("Standard Kelly strategy without conformal guard.")


### PR DESCRIPTION
## Summary
- implement Venn-Abers style conformal calibrator with Mondrian indexing
- add lower-bound edge rule and Conformal-Kelly sizing
- integrate conformal guard in backtester with config and schemas

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bed1d592ac832b8edbdefb2347b467