### PR TITLE
Add CLI for ingest key spec validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install . pytest
+      - name: Validate key spec
+        run: python -m engine.ingest.keys --check
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # bettingedge
+
+## Verifica mappa chiavi
+
+Per validare la spec delle chiavi di ingestione:
+
+```
+python -m engine.ingest.keys --check
+python -m engine.ingest.keys --sample data/raw/l1_24_25.csv
+# oppure
+bettingedge-keys --check
+```

--- a/engine/ingest/__init__.py
+++ b/engine/ingest/__init__.py
@@ -1,0 +1,4 @@
+"""Ingestion utilities for BettingEdge."""
+
+__all__: list[str] = []
+

--- a/engine/ingest/_keys_schema.py
+++ b/engine/ingest/_keys_schema.py
@@ -1,0 +1,54 @@
+"""Pydantic models describing football data key specifications."""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+
+class Section(BaseModel):
+    """Groups of fields for a particular data section."""
+    required: Optional[List[str]] = None
+    optional: Optional[List[str]] = None
+    required_any: Optional[List[str]] = None
+    fields: Optional[List[str]] = None
+    fields_any: Optional[List[str]] = None
+
+
+class Aliases(BaseModel):
+    """Aliases for common result columns."""
+    FTHG: List[str]
+    FTAG: List[str]
+    FTR: List[str]
+    HTHG: Optional[List[str]] = None
+    HTAG: Optional[List[str]] = None
+    HTR: Optional[List[str]] = None
+
+
+class Constraints(BaseModel):
+    """Constraints used when ingesting data."""
+    min_odds: float
+    max_odds: float
+    max_overround_1x2: float
+    timezone: str
+    date_format: str
+
+
+class Notes(BaseModel):
+    """Additional notes describing the specification."""
+    closing_suffix: str
+    description: str
+
+
+class FootballDataKeys(BaseModel):
+    """Schema for the football_data_keys.yaml specification."""
+    results: Section
+    odds_1x2_pre: Section
+    odds_1x2_close: Section
+    ou_25_pre: Section
+    ou_25_close: Section
+    asian_handicap_pre: Section
+    asian_handicap_close: Section
+    aliases: Aliases
+    constraints: Constraints
+    notes: Notes
+

--- a/engine/ingest/keys.py
+++ b/engine/ingest/keys.py
@@ -1,0 +1,82 @@
+"""Command-line interface to validate football data key specification."""
+from __future__ import annotations
+
+import sys
+import argparse
+import json
+import pathlib
+from typing import Any
+
+import yaml
+import pandas as pd
+
+from ._keys_schema import FootballDataKeys
+
+# Default path to the YAML specification
+DEF_SPEC = pathlib.Path(__file__).resolve().parents[1] / "data" / "specs" / "football_data_keys.yaml"
+
+
+def load_spec(path: pathlib.Path) -> FootballDataKeys:
+    """Load and validate the key specification from YAML."""
+    with open(path, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+    return FootballDataKeys(**raw)
+
+
+def check_sample_csv(spec: FootballDataKeys, csv_path: pathlib.Path) -> dict[str, Any]:
+    """Perform a light sanity check of a sample CSV against the spec."""
+    df = pd.read_csv(csv_path, nrows=100)
+    cols = set(df.columns)
+    issues: list[str] = []
+
+    # Example: ensure at least one typical 1X2 pre-match triplet exists
+    triplets = (
+        {f"{prefix}{suf}" for suf in ("H", "D", "A")}
+        for prefix in ("Avg", "Max", "B365", "BW", "IW", "PS")
+    )
+    has_any_pre = any(t.issubset(cols) for t in triplets)
+    if not has_any_pre:
+        issues.append(
+            "No obvious 1X2 pre-match triplet found in sample (e.g., AvgH/AvgD/AvgA)."
+        )
+
+    return {"ok": len(issues) == 0, "issues": issues, "columns": sorted(cols)}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--spec",
+        type=pathlib.Path,
+        default=DEF_SPEC,
+        help="Path to football_data_keys.yaml",
+    )
+    ap.add_argument(
+        "--sample",
+        type=pathlib.Path,
+        help="Optional sample CSV to sanity-check",
+    )
+    ap.add_argument(
+        "--check", action="store_true", help="Strict validation only"
+    )
+    args = ap.parse_args(argv)
+
+    rc = 0
+    try:
+        spec = load_spec(args.spec)
+        print("[OK] Loaded spec:", args.spec)
+        if args.sample and args.sample.exists():
+            res = check_sample_csv(spec, args.sample)
+            print(json.dumps({"sample_check": res}, indent=2))
+            if not res["ok"]:
+                rc = max(rc, 2)  # warning exit
+    except Exception as exc:  # pragma: no cover - we handle generically
+        print("[ERROR] Spec validation failed:", exc, file=sys.stderr)
+        rc = 1
+
+    return rc
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,6 @@ dependencies = [
 
 [project.optional-dependencies]
 torch = ["torch"]
+
+[project.scripts]
+bettingedge-keys = "engine.ingest.keys:main"

--- a/tests/test_ingest_keys_cli.py
+++ b/tests/test_ingest_keys_cli.py
@@ -1,0 +1,29 @@
+import subprocess
+import sys
+import pathlib
+
+
+def test_engine_ingest_keys_cli_runs():
+    cmd = [sys.executable, "-m", "engine.ingest.keys", "--check"]
+    rc = subprocess.run(cmd, capture_output=True, text=True).returncode
+    assert rc in (0, 2)  # 0 ok, 2 warning when sample missing
+
+
+def test_engine_ingest_keys_cli_with_sample(tmp_path):
+    sample = tmp_path / "mini.csv"
+    sample.write_text(
+        "Div,Date,Time,HomeTeam,AwayTeam,FTHG,FTAG,FTR,AvgH,AvgD,AvgA\n"
+        "E0,01/08/24,15:00,A,B,1,0,H,2.1,3.4,3.2\n"
+    )
+    cmd = [
+        sys.executable,
+        "-m",
+        "engine.ingest.keys",
+        "--spec",
+        str(pathlib.Path("engine/data/specs/football_data_keys.yaml")),
+        "--sample",
+        str(sample),
+        "--check",
+    ]
+    rc = subprocess.run(cmd, capture_output=True, text=True).returncode
+    assert rc in (0, 2)


### PR DESCRIPTION
## Summary
- add `engine.ingest.keys` CLI to validate `football_data_keys.yaml` and optional sample CSV
- define lightweight Pydantic schema for ingest key spec
- document key spec verification and expose `bettingedge-keys` console script
- run key spec validation in CI

## Testing
- `python -m engine.ingest.keys --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bedf3df0cc832b90fb538a241e65a1