### PR TITLE
Refactor packaging for flat engine layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Install dependencies
+      - name: Install package
         run: |
           python -m pip install --upgrade pip
-          pip install . pytest
+          pip install -e .[dev] || pip install -e .
       - name: Validate key spec
         run: python -m engine.ingest.keys --check
       - name: Run tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+recursive-include engine/data/specs *.yaml
+recursive-include engine/eval/templates *.html *.htm

--- a/engine/data/ingest.py
+++ b/engine/data/ingest.py
@@ -9,11 +9,15 @@ import pandas as pd
 import yaml
 import duckdb
 from zoneinfo import ZoneInfo
+from importlib.resources import files
 
 from .vig import remove_vig_multiplicative, remove_vig_shin
 from .bookmaker_fusion import fuse_1x2
 
-SPEC_PATH = Path("engine/data/specs/football_data_keys.yaml")
+try:
+    SPEC_PATH = files("engine.data.specs") / "football_data_keys.yaml"
+except Exception:  # pragma: no cover - fallback for unusual setups
+    SPEC_PATH = Path("engine/data/specs/football_data_keys.yaml")
 DB_PATH = Path("data/processed/football.duckdb")
 
 

--- a/engine/ingest/keys.py
+++ b/engine/ingest/keys.py
@@ -9,11 +9,20 @@ from typing import Any
 
 import yaml
 import pandas as pd
+from importlib.resources import files
 
 from ._keys_schema import FootballDataKeys
 
 # Default path to the YAML specification
-DEF_SPEC = pathlib.Path(__file__).resolve().parents[1] / "data" / "specs" / "football_data_keys.yaml"
+try:
+    DEF_SPEC = files("engine.data.specs") / "football_data_keys.yaml"
+except Exception:  # pragma: no cover - fallback for unusual setups
+    DEF_SPEC = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "data"
+        / "specs"
+        / "football_data_keys.yaml"
+    )
 
 
 def load_spec(path: pathlib.Path) -> FootballDataKeys:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,12 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "bettingedge"
-version = "0.1.0"
-description = "BettingEdge engine."
+version = "0.0.1"
+description = "Betting research engine"
+readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "hydra-core",
@@ -24,3 +29,15 @@ torch = ["torch"]
 
 [project.scripts]
 bettingedge-keys = "engine.ingest.keys:main"
+
+[tool.setuptools]
+package-dir = {"" = "."}
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["engine*"]
+exclude = ["tests*", "docs*", "ui*", "data*"]
+
+[tool.setuptools.package-data]
+engine = ["data/specs/*.yaml", "eval/templates/*.html", "eval/templates/*.htm"]

--- a/tests/test_ingest_keys_cli.py
+++ b/tests/test_ingest_keys_cli.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 import pathlib
+from importlib.resources import files
 
 
 def test_engine_ingest_keys_cli_runs():
@@ -15,12 +16,13 @@ def test_engine_ingest_keys_cli_with_sample(tmp_path):
         "Div,Date,Time,HomeTeam,AwayTeam,FTHG,FTAG,FTR,AvgH,AvgD,AvgA\n"
         "E0,01/08/24,15:00,A,B,1,0,H,2.1,3.4,3.2\n"
     )
+    spec = files("engine.data.specs") / "football_data_keys.yaml"
     cmd = [
         sys.executable,
         "-m",
         "engine.ingest.keys",
         "--spec",
-        str(pathlib.Path("engine/data/specs/football_data_keys.yaml")),
+        str(spec),
         "--sample",
         str(sample),
         "--check",


### PR DESCRIPTION
## Summary
- switch to PEP 621 setuptools config and restrict package discovery to `engine*`
- add manifest and package-data for YAML/HTML assets
- use `importlib.resources` to load key specs
- install package in editable mode in CI

## Testing
- `python -m pip install --no-deps .`
- `python -m pip install --no-deps -e .`
- `python -m engine.ingest.keys --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee37bd108832bb85f135f3346a7cf