### PR TITLE
CI fix: extras dev install and python -m pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-      - name: Install package
+          python-version: "3.11"
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Install package (with dev extras)
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev] || pip install -e .
+          pip install -e .[dev] || true
+          # fallback nel caso gli extras non fossero risolti (vecchie pip):
+          pip install -e .
+          pip install pytest pytest-cov
       - name: Validate key spec
         run: python -m engine.ingest.keys --check
       - name: Run tests
-        run: pytest -q
+        run: python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ python -m engine.ingest.keys --sample data/raw/l1_24_25.csv
 # oppure
 bettingedge-keys --check
 ```
+
+## Dev setup
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e .[dev]
+python -m pytest -q
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = [
+  "pytest>=7",
+  "pytest-cov>=4",
+  "pre-commit>=3",
+  "black>=24.3",
+  "isort>=5.13",
+  "ruff>=0.5",
+  "mypy>=1.8",
+]
 torch = ["torch"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add comprehensive `dev` extras for testing and tooling
- install dev extras in CI and run `python -m pytest`
- document development setup steps

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee6835da4832bba50b62a387e541f