### PR TITLE
Add SHAP-based explainability and rule playbook utilities

### DIFF
--- a/engine/config/model.yaml
+++ b/engine/config/model.yaml
@@ -36,3 +36,15 @@ conformal:
   mondrian_keys: []
   min_group_size: 100
   width_cap: 0.6
+
+explain:
+  shap:
+    bg_size: 2000
+    topk_local: 8
+  playbook:
+    edge_thr: 0.02
+    min_coverage: 0.02
+    min_precision: 0.55
+    min_lift: 1.2
+    max_depth: 4
+    n_rules: 200

--- a/engine/eval/feature_assembly.py
+++ b/engine/eval/feature_assembly.py
@@ -5,7 +5,7 @@ from typing import Tuple
 
 import pandas as pd
 
-__all__ = ["assemble_ensemble_features"]
+__all__ = ["assemble_ensemble_features", "assemble_explain_matrix"]
 
 
 def assemble_ensemble_features(
@@ -44,3 +44,20 @@ def assemble_ensemble_features(
     X = df[cols].copy()
     y = df["y_wdl"].copy()
     return X, y
+
+
+def assemble_explain_matrix(
+    df: pd.DataFrame, *, include_close: bool = False
+) -> Tuple[pd.DataFrame, pd.Series, pd.Series]:
+    """Assemble features, target and identifiers for explainability tasks.
+
+    This helper is a thin wrapper around :func:`assemble_ensemble_features` that
+    also returns the ``match_id`` column (if present) used to index SHAP values
+    and rule-based playbooks.
+    """
+
+    X, y = assemble_ensemble_features(df, include_close=include_close)
+    match_ids = df["match_id"] if "match_id" in df.columns else pd.Series(
+        range(len(df)), name="match_id"
+    )
+    return X, y, match_ids

--- a/engine/eval/metrics_edge.py
+++ b/engine/eval/metrics_edge.py
@@ -1,0 +1,38 @@
+"""Edge-level evaluation metrics."""
+from __future__ import annotations
+
+import numpy as np
+from sklearn.metrics import precision_score, recall_score
+
+__all__ = [
+    "edge_precision_recall",
+    "edge_gain_curve",
+    "stability_by_regime",
+]
+
+
+def edge_precision_recall(y_true: np.ndarray, edge_pred: np.ndarray, thr: float = 0.0):
+    """Compute precision and recall for positive edge predictions."""
+    y_hat = edge_pred >= thr
+    precision = precision_score(y_true, y_hat, zero_division=0)
+    recall = recall_score(y_true, y_hat, zero_division=0)
+    return precision, recall
+
+
+def edge_gain_curve(y_true: np.ndarray, edge_pred: np.ndarray) -> np.ndarray:
+    """Return cumulative gain curve ordering by predicted edge."""
+    order = np.argsort(-edge_pred)
+    cum_gain = np.cumsum(y_true[order])
+    if cum_gain.size:
+        cum_gain = cum_gain / cum_gain[-1]
+    return cum_gain
+
+
+def stability_by_regime(precisions: np.ndarray) -> float:
+    """Compute normalised variance of precisions across regimes."""
+    precisions = np.asarray(precisions)
+    if precisions.size == 0:
+        return float("nan")
+    mean = precisions.mean()
+    var = precisions.var()
+    return var / (mean * (1 - mean) + 1e-12)

--- a/engine/eval/schemas.py
+++ b/engine/eval/schemas.py
@@ -15,6 +15,11 @@ __all__ = [
     "diagnostics_reliability_schema",
     "diagnostics_pit_schema",
     "diagnostics_regimes_schema",
+    "explain_shap_global_schema",
+    "explain_shap_local_schema",
+    "explain_rules_schema",
+    "explain_rules_summary_schema",
+    "whatif_logs_schema",
 ]
 
 
@@ -157,6 +162,73 @@ diagnostics_regimes_schema = DataFrameSchema(
         "regime_id": Column(pa.Int64),
         "n": Column(pa.Int64),
         "kpi_json": Column(pa.Object),
+        "created_at": Column(pa.DateTime),
+    },
+    coerce=True,
+)
+
+
+explain_shap_global_schema = DataFrameSchema(
+    {
+        "feature": Column(pa.String),
+        "mean_abs": Column(pa.Float64),
+        "fold": Column(pa.Int64),
+        "created_at": Column(pa.DateTime),
+    },
+    coerce=True,
+)
+
+
+explain_shap_local_schema = DataFrameSchema(
+    {
+        "match_id": Column(pa.String),
+        "fold": Column(pa.Int64),
+        "feature": Column(pa.String),
+        "shap_value": Column(pa.Float64),
+        "base_value": Column(pa.Float64),
+        "created_at": Column(pa.DateTime),
+    },
+    coerce=True,
+)
+
+
+explain_rules_schema = DataFrameSchema(
+    {
+        "rule_id": Column(pa.String),
+        "rule": Column(pa.String),
+        "depth": Column(pa.Int64),
+        "support": Column(pa.Int64),
+        "coverage": Column(pa.Float64),
+        "precision": Column(pa.Float64),
+        "lift": Column(pa.Float64),
+        "fold": Column(pa.Int64),
+        "regime_id": Column(pa.Int64, nullable=True),
+        "created_at": Column(pa.DateTime),
+    },
+    coerce=True,
+)
+
+
+explain_rules_summary_schema = DataFrameSchema(
+    {
+        "stat": Column(pa.String),
+        "value": Column(pa.Float64),
+        "fold": Column(pa.Int64),
+        "created_at": Column(pa.DateTime),
+    },
+    coerce=True,
+)
+
+
+whatif_logs_schema = DataFrameSchema(
+    {
+        "match_id": Column(pa.String),
+        "feature": Column(pa.String),
+        "v0": Column(pa.Float64),
+        "v1": Column(pa.Float64),
+        "delta_p": Column(pa.Float64),
+        "delta_edge": Column(pa.Float64),
+        "policy": Column(pa.String),
         "created_at": Column(pa.DateTime),
     },
     coerce=True,

--- a/engine/explain/__init__.py
+++ b/engine/explain/__init__.py
@@ -1,0 +1,1 @@
+"""Explainability utilities for the BettingEdge engine."""

--- a/engine/explain/playbook.py
+++ b/engine/explain/playbook.py
@@ -1,0 +1,57 @@
+"""Utilities to aggregate and persist rule-based playbooks."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime
+from typing import Iterable
+
+import duckdb
+import pandas as pd
+
+from .rulefit import Rule
+
+__all__ = ["filter_rules", "persist_rules"]
+
+
+def filter_rules(
+    rules: Iterable[Rule],
+    *,
+    min_coverage: float,
+    min_precision: float,
+    min_lift: float,
+    max_depth: int,
+    fold: int,
+) -> pd.DataFrame:
+    """Filter rules according to KPI thresholds and return a dataframe."""
+    rows: list[dict] = []
+    for r in rules:
+        if (
+            r.coverage >= min_coverage
+            and r.precision >= min_precision
+            and r.lift >= min_lift
+            and r.depth <= max_depth
+        ):
+            rows.append(
+                {
+                    "rule_id": r.rule_id,
+                    "rule": r.rule,
+                    "depth": r.depth,
+                    "support": r.support,
+                    "coverage": r.coverage,
+                    "precision": r.precision,
+                    "lift": r.lift,
+                    "fold": fold,
+                    "created_at": datetime.utcnow(),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def persist_rules(conn: duckdb.DuckDBPyConnection, df: pd.DataFrame) -> None:
+    """Persist playbook rules into a DuckDB table."""
+    if df.empty:
+        return
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS explain_rules AS SELECT * FROM df LIMIT 0"
+    )
+    conn.execute("INSERT INTO explain_rules SELECT * FROM df")

--- a/engine/explain/rulefit.py
+++ b/engine/explain/rulefit.py
@@ -1,0 +1,98 @@
+"""Simple rule extraction utilities for the edge playbook."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+import numpy as np
+import pandas as pd
+from sklearn.tree import DecisionTreeClassifier
+
+__all__ = ["Rule", "fit_rule_playbook"]
+
+
+@dataclass
+class Rule:
+    """Container for a single decision rule."""
+
+    rule_id: str
+    rule: str
+    depth: int
+    support: int
+    coverage: float
+    precision: float
+    lift: float
+    fold: int | None = None
+
+
+def _walk_tree(tree, feature_names: List[str]):
+    """Yield rule strings and depth from a fitted ``DecisionTreeClassifier``."""
+
+    def recurse(node: int, conds: list[str]):
+        if tree.tree_.feature[node] == -2:  # leaf
+            rule = " & ".join(conds) if conds else "True"
+            yield rule, len(conds)
+        else:
+            feat = feature_names[tree.tree_.feature[node]]
+            thr = tree.tree_.threshold[node]
+            left_conds = conds + [f"{feat} <= {thr:.3f}"]
+            right_conds = conds + [f"{feat} > {thr:.3f}"]
+            yield from recurse(tree.tree_.children_left[node], left_conds)
+            yield from recurse(tree.tree_.children_right[node], right_conds)
+
+    yield from recurse(0, [])
+
+
+def fit_rule_playbook(
+    X: np.ndarray,
+    y_edge: np.ndarray,
+    feature_names: List[str],
+    *,
+    min_coverage: float = 0.02,
+    max_depth: int = 4,
+    n_rules: int = 100,
+) -> List[Rule]:
+    """Fit a simple decision tree and extract rules meeting the constraints."""
+    n_samples = X.shape[0]
+    # fit a flexible tree and enforce coverage constraints post-hoc
+    clf = DecisionTreeClassifier(
+        max_depth=max_depth,
+        min_samples_leaf=1,
+        random_state=0,
+        class_weight="balanced",
+        criterion="entropy",
+    )
+    clf.fit(X, y_edge)
+    base_rate = y_edge.mean() if len(y_edge) else 0.0
+    dfX = pd.DataFrame(X, columns=feature_names)
+    rules: List[Rule] = []
+    for idx, (rule_str, depth) in enumerate(_walk_tree(clf, feature_names)):
+        mask = np.ones(len(dfX), dtype=bool)
+        if rule_str != "True":
+            for cond in rule_str.split(" & "):
+                feat, op, thr = cond.split(" ")
+                thr = float(thr)
+                if op == "<=":
+                    mask &= dfX[feat] <= thr
+                else:
+                    mask &= dfX[feat] > thr
+        support = int(mask.sum())
+        coverage = support / n_samples
+        if coverage < min_coverage or depth == 0:
+            continue
+        precision = float(y_edge[mask].mean()) if support else 0.0
+        lift = precision / base_rate if base_rate else np.nan
+        rules.append(
+            Rule(
+                rule_id=str(idx),
+                rule=rule_str,
+                depth=depth,
+                support=support,
+                coverage=coverage,
+                precision=precision,
+                lift=lift,
+            )
+        )
+    rules.sort(key=lambda r: r.precision * r.coverage, reverse=True)
+    return rules[:n_rules]

--- a/engine/explain/shap_utils.py
+++ b/engine/explain/shap_utils.py
@@ -1,0 +1,110 @@
+"""SHAP utility functions for model explainability."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+import shap
+
+__all__ = ["shap_global", "shap_local"]
+
+
+def _get_shap_values(model, X_bg: pd.DataFrame, X_eval: pd.DataFrame):
+    """Compute shap values using TreeExplainer.
+
+    Parameters
+    ----------
+    model : fitted tree-based model with ``predict``/``predict_proba`` methods.
+    X_bg : pd.DataFrame
+        Background dataset used to initialise the explainer.
+    X_eval : pd.DataFrame
+        Evaluation dataset for which SHAP values are required.
+    """
+    explainer = shap.TreeExplainer(
+        model,
+        X_bg,
+        feature_perturbation="interventional",
+        model_output="probability",
+    )
+    shap_values = explainer.shap_values(X_eval)
+    base_value = explainer.expected_value
+    # For binary classification shap returns list
+    if isinstance(shap_values, list):
+        shap_values = shap_values[1]
+        if isinstance(base_value, Iterable):
+            base_value = base_value[1]
+    return shap_values, base_value
+
+
+def shap_global(
+    model,
+    X_bg: pd.DataFrame,
+    X_eval: pd.DataFrame,
+    feature_names: list[str],
+    fold: int,
+) -> pd.DataFrame:
+    """Compute global feature importance using mean absolute SHAP values.
+
+    Returns a dataframe with columns ``feature`` and ``mean_abs`` along with the
+    ``fold`` identifier and creation timestamp.
+    """
+    shap_values, _ = _get_shap_values(model, X_bg, X_eval)
+    df = (
+        pd.DataFrame(shap_values, columns=feature_names)
+        .abs()
+        .mean()
+        .reset_index()
+        .rename(columns={"index": "feature", 0: "mean_abs"})
+    )
+    df["fold"] = fold
+    df["created_at"] = datetime.utcnow()
+    return df
+
+
+def shap_local(
+    model,
+    X_bg: pd.DataFrame,
+    X_eval: pd.DataFrame,
+    match_ids: Iterable[str],
+    feature_names: list[str],
+    fold: int,
+    topk: int = 8,
+) -> pd.DataFrame:
+    """Compute local SHAP values for individual matches.
+
+    Parameters
+    ----------
+    model : fitted model
+    X_bg : pd.DataFrame
+        Background dataset for the explainer.
+    X_eval : pd.DataFrame
+        Rows for which explanations are desired.
+    match_ids : iterable
+        Identifiers for the rows in ``X_eval``.
+    feature_names : list[str]
+        Names of the features corresponding to the columns of ``X_eval``.
+    fold : int
+        Fold identifier.
+    topk : int, default ``8``
+        Number of features with highest absolute SHAP value to retain per row.
+    """
+    shap_values, base_value = _get_shap_values(model, X_bg, X_eval)
+    df_vals = pd.DataFrame(shap_values, columns=feature_names)
+    records: list[dict] = []
+    for i, mid in enumerate(match_ids):
+        row = df_vals.iloc[i]
+        top_features = row.abs().nlargest(min(topk, len(row)))
+        for feat in top_features.index:
+            records.append(
+                {
+                    "match_id": mid,
+                    "fold": fold,
+                    "feature": feat,
+                    "shap_value": row[feat],
+                    "base_value": base_value,
+                    "created_at": datetime.utcnow(),
+                }
+            )
+    return pd.DataFrame.from_records(records)

--- a/engine/explain/whatif.py
+++ b/engine/explain/whatif.py
@@ -1,0 +1,54 @@
+"""Minimal what-if analysis utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+__all__ = ["simulate_delta"]
+
+
+def simulate_delta(
+    match_row: pd.Series,
+    feature: str,
+    v1: float,
+    model,
+    feature_names: Sequence[str],
+    odds_col: str = "odds",
+) -> dict:
+    """Simulate the change in probability and edge for a single feature tweak.
+
+    Parameters
+    ----------
+    match_row : pd.Series
+        Row containing the feature values and odds.
+    feature : str
+        Name of the feature to modify.
+    v1 : float
+        New value to assign to ``feature``.
+    model : classifier with ``predict_proba`` method.
+    feature_names : sequence of str
+        Names of the features expected by the model.
+    odds_col : str, default ``"odds"``
+        Column name holding the decimal odds used for edge computation.
+    """
+    X0 = match_row[feature_names].to_frame().T
+    p0 = model.predict_proba(X0)[0, 1]
+    odds = match_row[odds_col]
+    edge0 = p0 * odds - 1
+
+    X1 = X0.copy()
+    X1[feature] = v1
+    p1 = model.predict_proba(X1)[0, 1]
+    edge1 = p1 * odds - 1
+
+    return {
+        "delta_p": p1 - p0,
+        "delta_edge": edge1 - edge0,
+        "p0": p0,
+        "p1": p1,
+        "edge0": edge0,
+        "edge1": edge1,
+    }

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,75 @@
+import numpy as np
+import numpy as np
+import pandas as pd
+import shap
+from sklearn.datasets import make_classification
+from sklearn.model_selection import train_test_split
+from sklearn.linear_model import LogisticRegression
+from lightgbm import LGBMClassifier
+
+from engine.explain.shap_utils import shap_global, shap_local
+from engine.explain.rulefit import fit_rule_playbook
+from engine.explain.whatif import simulate_delta
+
+
+def test_shap_global_local():
+    X, y = make_classification(
+        n_samples=200, n_features=3, n_informative=1, random_state=0, n_clusters_per_class=1
+    )
+    feature_names = [f"f{i}" for i in range(X.shape[1])]
+    X_bg, X_eval, y_bg, y_eval = train_test_split(
+        X, y, test_size=0.5, random_state=1
+    )
+    model = LGBMClassifier(n_estimators=50, random_state=0)
+    model.fit(X_bg, y_bg)
+
+    df_global = shap_global(model, pd.DataFrame(X_bg, columns=feature_names), pd.DataFrame(X_eval, columns=feature_names), feature_names, fold=0)
+    top_feature = df_global.sort_values("mean_abs", ascending=False).iloc[0]["feature"]
+    assert top_feature == "f0"
+
+    match_ids = [f"m{i}" for i in range(len(X_eval))]
+    df_local = shap_local(
+        model,
+        pd.DataFrame(X_bg, columns=feature_names),
+        pd.DataFrame(X_eval[:1], columns=feature_names),
+        match_ids[:1],
+        feature_names,
+        fold=0,
+        topk=3,
+    )
+    explainer = shap.TreeExplainer(
+        model, pd.DataFrame(X_bg, columns=feature_names), model_output="probability"
+    )
+    shap_vals = explainer.shap_values(
+        pd.DataFrame(X_eval[:1], columns=feature_names)
+    )
+    base = explainer.expected_value
+    if isinstance(shap_vals, list):
+        shap_vals = shap_vals[1]
+        base = base[1]
+    pred = model.predict_proba(X_eval[:1])[0, 1]
+    assert np.isclose(df_local["shap_value"].sum() + base, pred, atol=1e-2)
+
+
+def test_rulefit_recovers_rule():
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(rng.normal(size=(1000, 3)), columns=["x1", "x2", "x3"])
+    y = ((X["x1"] > 0.5) & (X["x2"] < 0)).astype(int)
+    rules = fit_rule_playbook(X.values, y.values, list(X.columns), min_coverage=0.05)
+    found = False
+    for r in rules:
+        if "x1 >" in r.rule and "x2 <=" in r.rule and r.precision > 0.7 and r.coverage > 0.1:
+            found = True
+            break
+    assert found
+
+
+def test_whatif_delta_sign():
+    X = pd.DataFrame({"x1": [0.0, 1.0], "x2": [1.0, 1.0]})
+    y = np.array([0, 1])
+    model = LogisticRegression().fit(X, y)
+    row = X.iloc[0].copy()
+    row["odds"] = 2.0
+    result = simulate_delta(row, "x1", 1.0, model, ["x1", "x2"])
+    assert result["delta_p"] >= 0
+    assert result["delta_edge"] >= 0

--- a/ui/pages/07_🧠_Explain.py
+++ b/ui/pages/07_🧠_Explain.py
@@ -1,0 +1,19 @@
+"""Explainability dashboard placeholder."""
+import streamlit as st
+import pandas as pd
+
+st.set_page_config(page_title="Explain", layout="wide")
+
+st.title("🧠 Explain")
+
+st.header("Global Importance")
+st.info("Global SHAP values will appear here.")
+
+st.header("Local Cases")
+st.info("Select a match to view local SHAP waterfall plot.")
+
+st.header("Rule Playbook")
+st.info("Discovered rules and their KPIs will be listed here.")
+
+st.header("What-If Analysis")
+st.info("Interactively tweak features to see edge changes.")


### PR DESCRIPTION
## Summary
- add SHAP utilities for global and local feature attributions
- introduce rule extraction playbook and what-if simulation tools
- expose edge-level metrics and Streamlit explain page

## Testing
- `pytest tests/test_explain.py`
- `pytest` *(fails: Command '['python', '-m', 'engine.ingest.keys']' returned non-zero exit status 1.)*


------
https://chatgpt.com/codex/tasks/task_e_68bedb117428832babab0a25cec73bfa