### PR TITLE
ci: guard against importlib shadowing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,14 @@ jobs:
       - name: Show environment (debug)
         run: |
           python -V
-          python -c "import sys,platform; print(platform.platform())"
-          python -c "import numpy; print('numpy', numpy.__version__)"
-          python -c "import importlib, pkgutil; print('shap?', importlib.util.find_spec('shap') is not None)"
-          python -c "import importlib; print('lightgbm?', importlib.util.find_spec('lightgbm') is not None)"
+          python -c "import platform; print(platform.platform())"
+          python - <<'PY'
+import sys, numpy, pkgutil, importlib
+print('numpy', numpy.__version__)
+print('importlib module file:', getattr(importlib, '__file__', 'builtin'))
+print('shap?', pkgutil.find_loader('shap') is not None)
+print('lightgbm?', pkgutil.find_loader('lightgbm') is not None)
+PY
       - name: Validate key spec
         run: python -m engine.ingest.keys --check
       - name: Run tests

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,9 +1,20 @@
 import numpy as np
 import pandas as pd
-import pytest
+import pkgutil, pytest
 
-shap = pytest.importorskip("shap", reason="shap non installato nell'ambiente CI")
-lgbm = pytest.importorskip("lightgbm", reason="lightgbm non installato nell'ambiente CI")
+HAS_SHAP = pkgutil.find_loader("shap") is not None
+HAS_LGBM = pkgutil.find_loader("lightgbm") is not None
+
+pytestmark = [
+    pytest.mark.skipif(not HAS_SHAP, reason="shap non installato"),
+    pytest.mark.skipif(not HAS_LGBM, reason="lightgbm non installato"),
+]
+
+if HAS_SHAP:
+    import shap
+if HAS_LGBM:
+    import lightgbm as lgbm
+
 imodels = pytest.importorskip(
     "imodels",
     reason="imodels opzionale; se manca si skippa",

--- a/tests/test_meta_learner.py
+++ b/tests/test_meta_learner.py
@@ -1,9 +1,14 @@
 import numpy as np
 import pandas as pd
-import pytest
+import pkgutil, pytest
 
 from engine.eval.feature_assembly import assemble_ensemble_features
-from engine.models.meta_learner import MetaEnsemble
+
+HAS_LGBM = pkgutil.find_loader("lightgbm") is not None
+pytestmark = pytest.mark.skipif(not HAS_LGBM, reason="lightgbm non installato")
+
+if HAS_LGBM:
+    from engine.models.meta_learner import MetaEnsemble
 
 
 def _generate_df(n: int = 100, seed: int = 0) -> pd.DataFrame:

--- a/tests/test_no_stdlib_shadowing.py
+++ b/tests/test_no_stdlib_shadowing.py
@@ -1,0 +1,16 @@
+import os
+from pathlib import Path
+
+FORBIDDEN = {"importlib.py", "importlib"}  # file o directory
+
+def test_no_importlib_shadowing():
+    root = Path(__file__).resolve().parents[1]  # repo root
+    offenders = []
+    for name in FORBIDDEN:
+        p = root / name
+        if p.exists():
+            # ignora virtualenv, build, .git, ecc.
+            parts = set(p.parts)
+            if not (".venv" in parts or "build" in parts or ".git" in parts or "dist" in parts):
+                offenders.append(str(p))
+    assert not offenders, f"Rimuovi/renomina questi path che oscurano la stdlib: {offenders}"


### PR DESCRIPTION
## Summary
- show Python's importlib path in CI and avoid importlib.util in environment checks
- replace importlib.util guards in tests with pkgutil and add lightgbm skip in meta learner tests
- add sentinel test to prevent local stdlib shadowing

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beefe10344832ba47bf075a1eba00b