### PR TITLE
Fix Streamlit imports and file watcher configuration

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,9 @@
+[server]
+# Avoid hitting Linux inotify limits on Streamlit Cloud/containers:
+# switch watcher from 'auto' (inotify) to 'poll' (portable, no limits).
+fileWatcherType = "poll"
+
+# (facoltativo, comodo)
+headless = true
+runOnSave = true
+enableCORS = false

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,1 @@
+# Makes 'ui' a proper Python package.

--- a/ui/pages/__init__.py
+++ b/ui/pages/__init__.py
@@ -1,0 +1,1 @@
+# Optional: helps with absolute imports when using multipage apps.

--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -1,6 +1,15 @@
 """Streamlit entry point for the BettingEdge dashboard."""
 from __future__ import annotations
 
+import os
+import sys
+
+# Ensure project root (repo root) is importable so "ui" and "engine" resolve.
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+# existing imports below
 import subprocess
 from datetime import datetime
 


### PR DESCRIPTION
## Summary
- ensure project root is on `sys.path` for Streamlit app
- make `ui` and `ui.pages` Python packages
- configure Streamlit to use polling file watcher and run headless without CORS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0379ea34832ba3f72be9596d5cc0