### PR TITLE
feat: derive average odds trio

### DIFF
--- a/engine/data/ingest.py
+++ b/engine/data/ingest.py
@@ -9,6 +9,7 @@ import logging
 from typing import Dict, List, Optional
 
 import pandas as pd
+import numpy as np
 import yaml
 import duckdb
 from zoneinfo import ZoneInfo
@@ -303,56 +304,144 @@ def parse_ou_ah(df: pd.DataFrame, spec: Dict):
     return ou_pre, ou_close, ah_pre, ah_close
 
 
+def _to_num(s: pd.Series) -> pd.Series:
+    """Coerce to numeric odds, invalid values -> NaN. Discard non-sense (<=1)."""
+    x = pd.to_numeric(s, errors="coerce")
+    x = x.mask(~np.isfinite(x) | (x <= 1))
+    return x
+
+
+_BOOK_PREFIXES_1X2 = [
+    # principali presenti in Football-Data (varia per stagione/lega)
+    "B365",
+    "BS",
+    "BW",
+    "GB",
+    "IW",
+    "LB",
+    "PS",
+    "SO",
+    "SB",
+    "SJ",
+    "SY",
+    "VC",
+    "WH",
+    "P",
+]
+
+
+def _derive_avg_trio(odds_df: pd.DataFrame) -> pd.DataFrame:
+    """Derive or normalise AvgH/AvgD/AvgA columns in a robust way.
+
+    Priority order:
+    1. Use existing ``AvgH/AvgD/AvgA`` columns after numeric coercion.
+    2. Otherwise, compute the median across known bookmaker columns.
+    3. Fallback to ``PSH/PSD/PSA`` then ``MaxH/MaxD/MaxA`` when needed.
+    """
+
+    out = odds_df.copy()
+
+    # If Avg* columns already exist, just coerce and return
+    if all(c in out.columns for c in ("AvgH", "AvgD", "AvgA")):
+        out["AvgH"] = _to_num(out["AvgH"])
+        out["AvgD"] = _to_num(out["AvgD"])
+        out["AvgA"] = _to_num(out["AvgA"])
+        return out
+
+    # Gather bookmaker-specific columns for each outcome
+    cols_H = [f"{p}H" for p in _BOOK_PREFIXES_1X2 if f"{p}H" in out.columns]
+    cols_D = [f"{p}D" for p in _BOOK_PREFIXES_1X2 if f"{p}D" in out.columns]
+    cols_A = [f"{p}A" for p in _BOOK_PREFIXES_1X2 if f"{p}A" in out.columns]
+
+    def _median_across(cols: List[str]) -> pd.Series:
+        if not cols:
+            return pd.Series([pd.NA] * len(out), index=out.index, dtype="float64")
+        stack = pd.concat([_to_num(out[c]).rename(c) for c in cols], axis=1)
+        return stack.median(axis=1, skipna=True)
+
+    avgH = _median_across(cols_H)
+    avgD = _median_across(cols_D)
+    avgA = _median_across(cols_A)
+
+    # Fallback: PSH/PSD/PSA
+    for src, tgt in (("PSH", "AvgH"), ("PSD", "AvgD"), ("PSA", "AvgA")):
+        if src in out.columns:
+            v = _to_num(out[src])
+            if tgt == "AvgH":
+                avgH = avgH.fillna(v)
+            elif tgt == "AvgD":
+                avgD = avgD.fillna(v)
+            elif tgt == "AvgA":
+                avgA = avgA.fillna(v)
+
+    # Further fallback: MaxH/MaxD/MaxA
+    for src, tgt in (("MaxH", "AvgH"), ("MaxD", "AvgD"), ("MaxA", "AvgA")):
+        if src in out.columns:
+            v = _to_num(out[src])
+            if tgt == "AvgH":
+                avgH = avgH.fillna(v)
+            elif tgt == "AvgD":
+                avgD = avgD.fillna(v)
+            elif tgt == "AvgA":
+                avgA = avgA.fillna(v)
+
+    out["AvgH"], out["AvgD"], out["AvgA"] = avgH, avgD, avgA
+    return out
+
+
 def compute_market_probs(
     matches: pd.DataFrame, odds_pre: pd.DataFrame, odds_close: pd.DataFrame | None
 ) -> Dict[str, pd.DataFrame]:
     tables = {}
 
-    if {"AvgH", "AvgD", "AvgA"}.issubset(odds_pre.columns):
-        fused = odds_pre.apply(
-            lambda r: fuse_1x2([(r["AvgH"], r["AvgD"], r["AvgA"])])[:3],
-            axis=1,
-            result_type="expand",
+    # Derive/normalise AvgH/AvgD/AvgA in a robust way
+    odds_pre2 = _derive_avg_trio(odds_pre)
+
+    # Filter rows with complete trio to avoid NaNs in subsequent computations
+    mask_ok = odds_pre2[["AvgH", "AvgD", "AvgA"]].notna().all(axis=1)
+    if mask_ok.sum() == 0:
+        raise ValueError(
+            "Nessuna riga con trio di quote complete (AvgH/AvgD/AvgA). Verifica i CSV odds pre-match."
         )
-    else:
-        pre_cols = [c for c in odds_pre.columns if c != "MatchId"]
+    if (~mask_ok).any():
+        log.warning(
+            "compute_market_probs: scarto %s righe senza trio completo AvgH/AvgD/AvgA.",
+            int((~mask_ok).sum()),
+        )
+    pre_valid = odds_pre2.loc[mask_ok, ["MatchId", "AvgH", "AvgD", "AvgA"]]
 
-        def fuse_row(r):
-            books: Dict[str, Dict[str, float]] = {}
-            for c in pre_cols:
-                book = c[:-1]
-                outcome = c[-1]
-                books.setdefault(book, {})[outcome] = r[c]
-            obs = [
-                (vals["H"], vals["D"], vals["A"])
-                for vals in books.values()
-                if all(k in vals and pd.notna(vals[k]) for k in "HDA")
-            ]
-            if not obs:
-                return pd.Series([pd.NA, pd.NA, pd.NA])
-            fused = fuse_1x2(obs)
-            return pd.Series(fused[:3])
+    fused_vals = pre_valid.apply(
+        lambda r: fuse_1x2([(r["AvgH"], r["AvgD"], r["AvgA"])])[:3],
+        axis=1,
+        result_type="expand",
+    )
+    fused_vals.columns = ["H", "D", "A"]
 
-        fused = odds_pre.apply(fuse_row, axis=1)
-
-    base = pd.DataFrame(
-        {"MatchId": odds_pre["MatchId"], "H": fused[0], "D": fused[1], "A": fused[2]}
+    base_valid = pd.DataFrame(
+        {
+            "MatchId": pre_valid["MatchId"],
+            "H": fused_vals["H"],
+            "D": fused_vals["D"],
+            "A": fused_vals["A"],
+        },
+        index=pre_valid.index,
     )
 
-    probs_mul = base.apply(
+    probs_mul = base_valid.apply(
         lambda r: remove_vig_multiplicative(r["H"], r["D"], r["A"]),
         axis=1,
         result_type="expand",
     )
-    probs_shin = base.apply(
-        lambda r: remove_vig_shin(r["H"], r["D"], r["A"]), axis=1, result_type="expand"
+    probs_shin = base_valid.apply(
+        lambda r: remove_vig_shin(r["H"], r["D"], r["A"]),
+        axis=1,
+        result_type="expand",
     )
-    overround = base.apply(lambda r: sum(1.0 / r[["H", "D", "A"]]), axis=1)
+    overround = base_valid.apply(lambda r: sum(1.0 / r[["H", "D", "A"]]), axis=1)
     market_disagreement = (probs_mul - probs_shin).abs().sum(axis=1)
 
-    market_probs_pre = pd.DataFrame(
+    market_probs_pre_valid = pd.DataFrame(
         {
-            "MatchId": base["MatchId"],
             "pH_mul": probs_mul[0],
             "pD_mul": probs_mul[1],
             "pA_mul": probs_mul[2],
@@ -361,8 +450,13 @@ def compute_market_probs(
             "pA_shin": probs_shin[2],
             "overround_pre": overround,
             "market_disagreement": market_disagreement,
-        }
+        },
+        index=base_valid.index,
     )
+
+    # Reattach to original index, leaving NaNs for rows without complete trio
+    market_probs_pre = pd.DataFrame({"MatchId": odds_pre2["MatchId"]})
+    market_probs_pre = market_probs_pre.join(market_probs_pre_valid)
     tables["market_probs_pre"] = market_probs_pre
 
     if odds_close is not None and {"AvgCH", "AvgCD", "AvgCA"}.issubset(


### PR DESCRIPTION
## Summary
- derive AvgH/AvgD/AvgA odds trio with fallbacks and numeric coercion
- filter incomplete odds rows when computing market probabilities and warn

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1fdbb2d0832b8a02b9177791f1c9