### PR TITLE
Handle missing market probabilities

### DIFF
--- a/engine/data/contracts.py
+++ b/engine/data/contracts.py
@@ -34,12 +34,32 @@ if pa:
 
     MarketProbsSchema = pa.DataFrameSchema(
         {
-            "pH": pa.Column(float, checks=[pa.Check.ge(0), pa.Check.le(1)]),
-            "pD": pa.Column(float, checks=[pa.Check.ge(0), pa.Check.le(1)]),
-            "pA": pa.Column(float, checks=[pa.Check.ge(0), pa.Check.le(1)]),
+            "pH": pa.Column(
+                float,
+                checks=pa.Check(lambda s: s.isna() | ((s >= 0) & (s <= 1))),
+                nullable=True,
+                required=False,
+            ),
+            "pD": pa.Column(
+                float,
+                checks=pa.Check(lambda s: s.isna() | ((s >= 0) & (s <= 1))),
+                nullable=True,
+                required=False,
+            ),
+            "pA": pa.Column(
+                float,
+                checks=pa.Check(lambda s: s.isna() | ((s >= 0) & (s <= 1))),
+                nullable=True,
+                required=False,
+            ),
         },
         checks=pa.Check(
-            lambda df: ((df["pH"] + df["pD"] + df["pA"] - 1).abs() <= 1e-6).all()
+            lambda df: (
+                df[["pH", "pD", "pA"]]
+                .dropna()
+                .apply(lambda r: abs(r.sum() - 1) <= 1e-6, axis=1)
+                .all()
+            )
         ),
     )
 else:  # pragma: no cover - placeholders when pandera unavailable

--- a/tests/test_data_contracts.py
+++ b/tests/test_data_contracts.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 import pandera as pa
 import pytest
 
@@ -80,13 +81,32 @@ def invalid_probs(valid_probs):
     return df
 
 
+@pytest.fixture
+def nan_probs():
+    return pd.DataFrame({"pH": [0.5], "pD": [np.nan], "pA": [0.5]})
+
+
+@pytest.fixture
+def invalid_probs_range():
+    return pd.DataFrame({"pH": [1.2], "pD": [0.3], "pA": [0.5]})
+
+
 def test_probs_valid(valid_probs):
     validate_or_raise(valid_probs, MarketProbsSchema, "probs")
+
+
+def test_probs_nan_valid(nan_probs):
+    validate_or_raise(nan_probs, MarketProbsSchema, "probs")
 
 
 def test_probs_invalid(invalid_probs):
     with pytest.raises(pa.errors.SchemaError):
         validate_or_raise(invalid_probs, MarketProbsSchema, "probs")
+
+
+def test_probs_invalid_range(invalid_probs_range):
+    with pytest.raises(pa.errors.SchemaError):
+        validate_or_raise(invalid_probs_range, MarketProbsSchema, "probs")
 
 
 def test_ingest_valid():


### PR DESCRIPTION
## Summary
- allow Pandera schema for market probabilities to accept missing values while constraining existing ones to [0,1]
- compute market probabilities without dropping rows, log coverage and cast to float, and validate closing odds as well
- add tests for nullable probability columns and range checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf25fedd88832b878d154735adc2cf