### PR TITLE
Allow nullable Div in Pandera match schema

### DIFF
--- a/engine/data/contracts.py
+++ b/engine/data/contracts.py
@@ -14,7 +14,7 @@ except Exception:  # pragma: no cover - fallback
 if pa:
     MatchesSchema = pa.DataFrameSchema(
         {
-            "Div": pa.Column(str),
+            "Div": pa.Column(str, nullable=True),
             "HomeTeam": pa.Column(str),
             "AwayTeam": pa.Column(str),
             "FTHG": pa.Column(int, checks=pa.Check.ge(0)),


### PR DESCRIPTION
## Summary
- permit missing `Div` values when validating match data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf28766378832bb0d5ac4fd6b2a9f3