### PR TITLE
Handle empty rows in CSV ingest

### DIFF
--- a/engine/data/ingest.py
+++ b/engine/data/ingest.py
@@ -537,7 +537,7 @@ def ingest(source: str, commit: bool) -> Dict[str, pd.DataFrame]:
     ensure_dirs()
     spec = load_spec()
     df = pd.read_csv(source)
-    df = df.dropna(axis=1, how="all")
+    df = df.dropna(axis=1, how="all").dropna(how="all").convert_dtypes()
     df = parse_event_time(df, spec)
     results = parse_results(df, spec)
     validate_or_raise(results, MatchesSchema, "matches")

--- a/tests/test_ingest_dropna.py
+++ b/tests/test_ingest_dropna.py
@@ -1,0 +1,18 @@
+from engine.data import ingest
+
+
+def test_ingest_drops_all_nan_rows(tmp_path):
+    csv_content = (
+        "Div,Date,Time,HomeTeam,AwayTeam,FTHG,FTAG,FTR,AvgH,AvgD,AvgA\n"
+        "I1,01/01/2020,15:00,TeamA,TeamB,1,0,H,1.5,3.5,5.1\n"
+        "I1,02/01/2020,18:00,TeamC,TeamD,2,2,D,2.0,3.0,4.2\n"
+        + "," * 10 + "\n"
+    )
+    path = tmp_path / "sample.csv"
+    path.write_text(csv_content)
+
+    tables = ingest.ingest(str(path), commit=False)
+    matches = tables["matches"]
+
+    assert len(matches) == 2
+    assert matches["HomeTeam"].isna().sum() == 0


### PR DESCRIPTION
## Summary
- drop fully empty rows when reading raw match data and re-infer column types
- add regression test covering ingestion of files with blank lines

## Testing
- `pytest tests/test_ingest_dropna.py tests/test_ingest_keys.py tests/test_ingest_keys_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf2a683614832bbcf1a94da58b031b