### PR TITLE
Wire UI button to market probability engine

### DIFF
--- a/ui/pages/01_📥_Data_Load.py
+++ b/ui/pages/01_📥_Data_Load.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import streamlit as st
 
 from engine.data import ingest
+from engine.data.ingest import compute_market_probs, save_tables
+from engine.data.contracts import MarketProbsSchema, validate_or_raise
 from ui._io import read_duck
 
 st.title("📥 Data Load")
@@ -50,8 +52,34 @@ if st.button("Rebuild Market Probs"):
             odds_close = read_duck("SELECT * FROM odds_1x2_close")
         except Exception:
             odds_close = None
-        tables = ingest.compute_market_probs(matches, odds_pre, odds_close)
-        ingest.save_tables(tables)
-        st.success("Market probabilities rebuilt")
-    except Exception as exc:
-        st.error(f"Failed to rebuild market probabilities: {exc}")
+        probs = compute_market_probs(matches, odds_pre, odds_close)
+        try:
+            if "market_probs_pre" in probs:
+                validate_or_raise(
+                    probs["market_probs_pre"][["pH_mul", "pD_mul", "pA_mul"]].rename(
+                        columns={"pH_mul": "pH", "pD_mul": "pD", "pA_mul": "pA"}
+                    ),
+                    MarketProbsSchema,
+                    "market_probs_pre",
+                )
+            if "market_probs_close" in probs:
+                validate_or_raise(
+                    probs["market_probs_close"][["pH_mul", "pD_mul", "pA_mul"]].rename(
+                        columns={"pH_mul": "pH", "pD_mul": "pD", "pA_mul": "pA"}
+                    ),
+                    MarketProbsSchema,
+                    "market_probs_close",
+                )
+        except Exception as e:
+            st.error(f"Validazione fallita: {e}")
+            raise
+        save_tables(probs)
+        st.success("Market probabilities ricostruite e tabelle salvate.")
+        if isinstance(probs, dict) and probs:
+            name, df = next(iter(probs.items()))
+            st.write(f"Preview of {name}")
+            st.dataframe(df.head(50))
+    except Exception as e:
+        import traceback
+        st.error(f"Errore durante il rebuild delle market probs: {e}")
+        st.code("".join(traceback.format_exc()))


### PR DESCRIPTION
## Summary
- Hook `Rebuild Market Probs` button up to `compute_market_probs` and `save_tables`
- Validate and preview rebuilt market probabilities in the UI
- Add wiring test ensuring compute/save functions are invoked with proper DataFrames

## Testing
- `pytest tests/test_ui_wiring.py::test_data_load_rebuild -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf3a07ccb4832b8c4676a4938d117c