### PR TITLE
Add MLflow artifacts viewer to Streamlit UI

### DIFF
--- a/tests/test_mlflow_artifacts_viewer.py
+++ b/tests/test_mlflow_artifacts_viewer.py
@@ -1,0 +1,150 @@
+import importlib.util
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+import pandas as pd
+
+
+def load_module(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_mlflow_artifacts_viewer(monkeypatch, tmp_path):
+    # stub streamlit with minimal API
+    class SessionState(dict):
+        __getattr__ = dict.get
+        __setattr__ = dict.__setitem__
+
+    class STub:
+        session_state = SessionState()
+        secrets = {}
+
+        def set_page_config(self, *a, **k):
+            return None
+
+        def tabs(self, labels):
+            class Tab:
+                def __enter__(self_inner):
+                    return self
+
+                def __exit__(self_inner, *exc):
+                    return False
+
+            return [Tab() for _ in labels]
+
+        def write(self, *a, **k):
+            return None
+
+        def selectbox(self, *a, **k):
+            return 0
+
+        def line_chart(self, *a, **k):
+            return None
+
+        def download_button(self, *a, **k):
+            return None
+
+        def warning(self, *a, **k):
+            return None
+
+        def info(self, *a, **k):
+            return None
+
+        def caption(self, *a, **k):
+            return None
+
+        def divider(self, *a, **k):
+            return None
+
+        def title(self, *a, **k):
+            return None
+
+    st = STub()
+
+    class Sidebar:
+        def __enter__(self):
+            return st
+
+        def __exit__(self, *exc):
+            return False
+
+    st.sidebar = Sidebar()
+
+    class Components:
+        class v1:
+            @staticmethod
+            def html(*a, **k):
+                return None
+
+    st.components = Components()
+
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
+    # stub theme/state utilities
+    monkeypatch.setitem(sys.modules, "ui._theme", SimpleNamespace(inject_theme=lambda: None))
+    monkeypatch.setitem(sys.modules, "ui._state", SimpleNamespace(DUCK_PATH="duck", init_defaults=lambda: None))
+
+    # stub mlflow and client
+    called = {}
+
+    def fake_read_csv(path, *a, **k):
+        called["equity"] = Path(path)
+        return pd.DataFrame({"equity": [1, 2]})
+
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+
+    def fake_read_text(self, *a, **k):
+        called.setdefault("html", []).append(self)
+        return "<html></html>"
+
+    def fake_read_bytes(self, *a, **k):
+        return b"x"
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+    monkeypatch.setattr(Path, "read_bytes", fake_read_bytes)
+
+    class DummyClient:
+        def get_experiment_by_name(self, name):
+            return SimpleNamespace(experiment_id="1")
+
+        def search_runs(self, experiment_ids, max_results, order_by):
+            art_dir = tmp_path / "mlruns" / "1" / "run1" / "artifacts"
+            art_dir.mkdir(parents=True, exist_ok=True)
+            (art_dir / "equity.csv").write_text("eq\n1")
+            (art_dir / "diagnostics.html").write_text("<html></html>")
+            (art_dir / "playbook.html").write_text("<html></html>")
+            run1 = SimpleNamespace(
+                info=SimpleNamespace(
+                    run_id="run1",
+                    status="FINISHED",
+                    start_time=0,
+                    artifact_uri=art_dir.as_uri(),
+                )
+            )
+            run2 = SimpleNamespace(
+                info=SimpleNamespace(
+                    run_id="run2",
+                    status="FAILED",
+                    start_time=0,
+                    artifact_uri=art_dir.as_uri(),
+                )
+            )
+            return [run1, run2]
+
+    tracking_ns = SimpleNamespace(MlflowClient=DummyClient)
+    mlflow_stub = SimpleNamespace(
+        set_tracking_uri=lambda uri: None,
+        tracking=tracking_ns,
+    )
+    monkeypatch.setitem(sys.modules, "mlflow", mlflow_stub)
+    monkeypatch.setitem(sys.modules, "mlflow.tracking", tracking_ns)
+
+    load_module("ui/streamlit_app.py", "streamlit_app")
+
+    art_dir = tmp_path / "mlruns" / "1" / "run1" / "artifacts"
+    assert called["equity"] == art_dir / "equity.csv"
+    assert art_dir / "diagnostics.html" in called["html"]
+    assert art_dir / "playbook.html" in called["html"]

--- a/ui/README_UI.md
+++ b/ui/README_UI.md
@@ -16,6 +16,9 @@ The sidebar provides navigation across the pages:
 6. **Bet Sizing Simulator** – simulate stake policies.
 7. **Explain** – placeholder for explainability tools.
 
+The main page also exposes a **Results / MLflow Artifacts** tab showing outputs of
+MLflow runs for the `backtest` experiment.
+
 ## UI → Engine wiring
 
 | UI Action | Engine function | Artifacts shown |
@@ -28,3 +31,9 @@ The sidebar provides navigation across the pages:
 | **Build Ensemble** | `engine.eval.feature_assembly.assemble_ensemble_features` / `engine.models.meta_learner.MetaEnsemble` | blended probabilities, reliability plot |
 | **Run backtest** | `engine.eval.backtester.apply_conformal_guard` (+ `engine.eval.diagnostics.run_diagnostics`) | `equity.csv`, `diagnostics.html` |
 | **Compute diagnostics** | `engine.eval.diagnostics.run_diagnostics` | `diagnostics.html` |
+
+## MLflow Artifacts Viewer
+
+- The viewer reads the `MLFLOW_TRACKING_URI` from the environment or `st.secrets`.
+- If unset, it falls back to `file:/var/tmp/mlruns` (only local `file:` stores are supported).
+- Select a run to display `equity.csv`, `diagnostics.html` and `playbook.html` and download them.

--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -3,33 +3,33 @@ from __future__ import annotations
 
 import os
 import sys
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urlparse
+import traceback
+
+import pandas as pd
+import streamlit as st
+import mlflow
+from mlflow.tracking import MlflowClient
 
 # Ensure project root (repo root) is importable so "ui" and "engine" resolve.
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
-# existing imports below
-import subprocess
-from datetime import datetime
-
-import streamlit as st
-
-import os
-from pathlib import Path
-import streamlit as st
-
-# 1) Leggi il valore dai secrets e crea una cartella scrivibile su Cloud
-tracking_uri = st.secrets.get("MLFLOW_TRACKING_URI", "file:/var/tmp/mlruns")
-Path("/var/tmp/mlruns").mkdir(parents=True, exist_ok=True)  # /var/tmp è scrivibile su Cloud
-
-# 2) Espone la variabile d'ambiente per eventuale codice che la legge da os.environ
+# MLflow tracking URI resolution: env -> secrets -> fallback
+tracking_uri = (
+    os.environ.get("MLFLOW_TRACKING_URI")
+    or st.secrets.get("MLFLOW_TRACKING_URI")
+    or "file:/var/tmp/mlruns"
+)
+parsed_tracking = urlparse(tracking_uri)
+if parsed_tracking.scheme == "file":
+    Path(parsed_tracking.path).mkdir(parents=True, exist_ok=True)
 os.environ["MLFLOW_TRACKING_URI"] = tracking_uri
-
-# (facoltativo ma sicuro) Imposta anche via API MLflow se lo importi più sotto:
-import mlflow
 mlflow.set_tracking_uri(tracking_uri)
-
 
 from ui._state import DUCK_PATH, init_defaults
 from ui._theme import inject_theme
@@ -49,6 +49,97 @@ def _commit_sha() -> str:
         return "unknown"
 
 
+def render_mlflow_artifacts_viewer() -> None:
+    client = MlflowClient()
+    exp = client.get_experiment_by_name("backtest")
+    if exp is None:
+        st.info("Esegui Run backtest e riprova")
+        return
+    runs = client.search_runs(
+        experiment_ids=exp.experiment_id,
+        max_results=50,
+        order_by=["attributes.start_time DESC"],
+    )
+    if not runs:
+        st.info("Esegui Run backtest e riprova")
+        return
+    run_labels = [
+        f"{r.info.run_id} | {r.info.status} | "
+        f"{datetime.fromtimestamp(r.info.start_time / 1000).strftime('%Y-%m-%d %H:%M:%S')}"
+        for r in runs
+    ]
+    if "mlflow_run_index" not in st.session_state:
+        st.session_state.mlflow_run_index = 0
+    idx = st.selectbox(
+        "Run",
+        options=list(range(len(runs))),
+        index=st.session_state.mlflow_run_index,
+        format_func=lambda i: run_labels[i],
+    )
+    st.session_state.mlflow_run_index = idx
+    run = runs[idx]
+    artifact_uri = run.info.artifact_uri
+    st.write("Artifact URI:", artifact_uri)
+    parsed = urlparse(artifact_uri)
+    if parsed.scheme != "file":
+        st.warning("artifact store non locale: visualizzazione diretta non supportata")
+        return
+    artifact_dir = Path(parsed.path)
+    st.write("Artifact path:", artifact_dir)
+    equity_path = artifact_dir / "equity.csv"
+    diagnostics_path = artifact_dir / "diagnostics.html"
+    playbook_path = artifact_dir / "playbook.html"
+    if equity_path.exists():
+        try:
+            df = pd.read_csv(equity_path)
+            col = (
+                "equity"
+                if "equity" in df.columns
+                else df.select_dtypes("number").columns.to_list()[0]
+                if not df.select_dtypes("number").empty
+                else None
+            )
+            if col:
+                st.line_chart(df[col])
+            else:
+                st.write(df)
+            st.download_button(
+                "Download equity.csv", data=equity_path.read_bytes(), file_name="equity.csv"
+            )
+        except Exception:
+            st.error(traceback.format_exc())
+    else:
+        st.warning("equity.csv non trovato")
+    if diagnostics_path.exists():
+        try:
+            st.components.v1.html(
+                diagnostics_path.read_text(), height=700, scrolling=True
+            )
+            st.download_button(
+                "Download diagnostics.html",
+                data=diagnostics_path.read_bytes(),
+                file_name="diagnostics.html",
+            )
+        except Exception:
+            st.error(traceback.format_exc())
+    else:
+        st.warning("diagnostics.html non trovato")
+    if playbook_path.exists():
+        try:
+            st.components.v1.html(
+                playbook_path.read_text(), height=700, scrolling=True
+            )
+            st.download_button(
+                "Download playbook.html",
+                data=playbook_path.read_bytes(),
+                file_name="playbook.html",
+            )
+        except Exception:
+            st.error(traceback.format_exc())
+    else:
+        st.warning("playbook.html non trovato")
+
+
 with st.sidebar:
     st.title("bettingedge")
     st.caption(f"{_commit_sha()} • {datetime.now().strftime('%Y-%m-%d')}")
@@ -57,4 +148,8 @@ with st.sidebar:
     st.divider()
     st.write("Select a page above to get started.")
 
-st.write("Use the sidebar to navigate between pages.")
+tab_home, tab_results = st.tabs(["Welcome", "Results / MLflow Artifacts"])
+with tab_home:
+    st.write("Use the sidebar to navigate between pages.")
+with tab_results:
+    render_mlflow_artifacts_viewer()


### PR DESCRIPTION
## Summary
- expose MLflow artifacts from `backtest` runs in a new "Results / MLflow Artifacts" tab
- resolve `MLFLOW_TRACKING_URI` from env/secrets with fallback to local `file:/var/tmp/mlruns`
- document and test the artifacts viewer wiring

## Testing
- `pytest tests/test_mlflow_artifacts_viewer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bfe5846ea4832bb7ba2e91e9f83f9b