### PR TITLE
feat(ui): wire backtest page to mlflow artifacts

### DIFF
--- a/tests/test_backtest_artifacts_display.py
+++ b/tests/test_backtest_artifacts_display.py
@@ -1,0 +1,131 @@
+import importlib.util
+import sys
+from pathlib import Path
+import pandas as pd
+
+
+def load_module(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_backtest_page_reads_artifacts(monkeypatch, tmp_path):
+    art_dir = tmp_path / "mlruns" / "0" / "r1" / "artifacts"
+    art_dir.mkdir(parents=True, exist_ok=True)
+    (art_dir / "equity.csv").write_text("equity\n1")
+    (art_dir / "diagnostics.html").write_text("<html></html>")
+
+    called = {}
+
+    def fake_read_csv(path, *a, **k):
+        called["equity"] = Path(path)
+        return pd.DataFrame({"equity": [1, 2]})
+
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+
+    orig_read_text = Path.read_text
+    orig_read_bytes = Path.read_bytes
+
+    def fake_read_text(self, *a, **k):
+        if self.suffix in {".html", ".csv"}:
+            called.setdefault("html", []).append(self)
+            return "<html></html>"
+        return orig_read_text(self, *a, **k)
+
+    def fake_read_bytes(self, *a, **k):
+        if self.suffix in {".html", ".csv"}:
+            return b"x"
+        return orig_read_bytes(self, *a, **k)
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+    monkeypatch.setattr(Path, "read_bytes", fake_read_bytes)
+
+    class Tab:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    class STub:
+        session_state = {
+            "mlflow_run_id": "r1",
+            "artifacts_root": art_dir,
+            "show_artifacts": True,
+        }
+        secrets = {}
+
+        def title(self, *a, **k):
+            return None
+
+        def tabs(self, labels):
+            return Tab(), Tab()
+
+        def checkbox(self, *a, **k):
+            return False
+
+        def slider(self, *a, **k):
+            return 0.1
+
+        def multiselect(self, *a, **k):
+            return []
+
+        def number_input(self, *a, **k):
+            return 1
+
+        def write(self, *a, **k):
+            return None
+
+        def button(self, *a, **k):
+            return False
+
+        def header(self, *a, **k):
+            return None
+
+        def selectbox(self, *a, **k):
+            return None
+
+        def line_chart(self, *a, **k):
+            return None
+
+        def download_button(self, label, *a, **k):
+            called.setdefault("download", []).append(label)
+            return None
+
+        class components:
+            class v1:
+                @staticmethod
+                def html(*a, **k):
+                    called.setdefault("html_embed", []).append(a[0])
+                    return None
+
+        def info(self, *a, **k):
+            return None
+
+        def success(self, *a, **k):
+            return None
+
+        def warning(self, *a, **k):
+            return None
+
+        def error(self, *a, **k):
+            return None
+
+        def code(self, *a, **k):
+            return None
+
+        def metric(self, *a, **k):
+            return None
+
+    st = STub()
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
+    load_module("ui/pages/04_📈_Backtest.py", "backtest_page")
+
+    assert called["equity"] == art_dir / "equity.csv"
+    assert art_dir / "diagnostics.html" in called["html"]
+    assert "Scarica equity.csv" in called["download"]
+    assert "Scarica diagnostics.html" in called["download"]
+

--- a/tests/test_ui_wiring.py
+++ b/tests/test_ui_wiring.py
@@ -67,6 +67,15 @@ def test_data_load_rebuild(monkeypatch, tmp_path):
         def code(self, *a, **k):
             return None
 
+        def code(self, *a, **k):
+            return None
+
+        def code(self, *a, **k):
+            return None
+
+        def code(self, *a, **k):
+            return None
+
         def dataframe(self, *a, **k):
             return None
 
@@ -168,6 +177,9 @@ def test_backtest_calls_engine(monkeypatch, tmp_path):
         def error(self, *a, **k):
             return None
 
+        def code(self, *a, **k):
+            return None
+
     st = STub()
     monkeypatch.setitem(sys.modules, "streamlit", st)
 
@@ -187,5 +199,5 @@ def test_backtest_calls_engine(monkeypatch, tmp_path):
     monkeypatch.setattr("engine.utils.mlflow_utils.end_run", lambda *a, **k: None)
     (tmp_path / "d.html").write_text("<html></html>")
 
-    load_module("bettingedge/ui/pages/04_📈_Backtest.py", "backtest")
+    load_module("ui/pages/04_📈_Backtest.py", "backtest")
     assert called.get("apply")


### PR DESCRIPTION
## Summary
- persist mlflow run id and local artifact root in Streamlit session state
- render equity, diagnostics report and metrics from mlflow artifacts with download buttons
- add regression test for artifact loading and update wiring tests

## Testing
- `pytest tests/test_backtest_artifacts_display.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfe91543ec832b890161e6aa007c42