### PR TITLE
Integrate MLflow artifacts in backtest UI

### DIFF
--- a/tests/test_ui_wiring.py
+++ b/tests/test_ui_wiring.py
@@ -1,5 +1,6 @@
 import importlib.util
 import sys
+from types import SimpleNamespace
 
 import pandas as pd
 
@@ -156,6 +157,9 @@ def test_backtest_calls_engine(monkeypatch, tmp_path):
         def header(self, *a, **k):
             return None
 
+        def subheader(self, *a, **k):
+            return None
+
         def selectbox(self, *a, **k):
             return None
 
@@ -172,6 +176,9 @@ def test_backtest_calls_engine(monkeypatch, tmp_path):
             return None
 
         def info(self, *a, **k):
+            return None
+
+        def warning(self, *a, **k):
             return None
 
         def error(self, *a, **k):
@@ -198,6 +205,21 @@ def test_backtest_calls_engine(monkeypatch, tmp_path):
     monkeypatch.setattr("engine.utils.mlflow_utils.log_artifact", lambda *a, **k: None)
     monkeypatch.setattr("engine.utils.mlflow_utils.end_run", lambda *a, **k: None)
     (tmp_path / "d.html").write_text("<html></html>")
+
+    class DummyClient:
+        def get_run(self, run_id):
+            return SimpleNamespace(info=SimpleNamespace(experiment_id="0", artifact_uri="file:/tmp"))
+
+        def get_metric_history(self, run_id, key):
+            return []
+
+        def get_experiment_by_name(self, name):
+            return None
+
+        def search_runs(self, *a, **k):
+            return []
+
+    monkeypatch.setattr("mlflow.tracking.MlflowClient", lambda: DummyClient())
 
     load_module("ui/pages/04_📈_Backtest.py", "backtest")
     assert called.get("apply")


### PR DESCRIPTION
## Summary
- Resolve latest MLflow backtest run and artifact directory in session state
- Display equity, diagnostics and playbook directly from MLflow artifacts with unique download buttons
- Read metrics via `MlflowClient` and show debug info for experiment/run
- Add tests covering MLflow wiring and update existing stubs

## Testing
- `pytest tests/test_backtest_artifacts_display.py::test_backtest_page_reads_artifacts -q`
- `pytest tests/test_backtest_mlflow_wiring.py::test_backtest_page_uses_mlflow_client -q`
- `pytest tests/test_ui_wiring.py::test_backtest_calls_engine -q`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bff61f9600832b85fd95138be08d52