### PR TITLE
Align UI with engine artifacts and MLflow

### DIFF
--- a/ui/README_UI.md
+++ b/ui/README_UI.md
@@ -19,6 +19,19 @@ The sidebar provides navigation across the pages:
 The main page also exposes a **Results / MLflow Artifacts** tab showing outputs of
 MLflow runs for the `backtest` experiment.
 
+The UI resolves a single `DATA_ROOT` at start from `DATA_ROOT` env var or
+`st.secrets`; if unset it defaults to `./data`. The value is stored in
+`st.session_state["DATA_ROOT"]` and all pages communicate paths via
+`st.session_state["raw_paths"]` and `st.session_state["processed_paths"]`.
+This avoids mismatches when moving from **Data Load** to **Rebuild Market Probs**
+to **Backtest**.
+
+Before any interaction with MLflow the `MLFLOW_TRACKING_URI` environment
+variable is set (env → `st.secrets` → `file:/var/tmp/mlruns`). The Backtest page
+reads metrics and artifacts for the current run through the MLflow API; results
+such as `equity.csv`, `diagnostics.html` and `playbook.html` are embedded
+directly from the run's artifact store.
+
 ## UI → Engine wiring
 
 | UI Action | Engine function | Artifacts shown |

--- a/ui/_io.py
+++ b/ui/_io.py
@@ -10,7 +10,11 @@ import streamlit as st
 from ._state import DUCK_PATH
 
 
-@st.cache_resource
+_cache_resource = getattr(st, "cache_resource", lambda **_: (lambda f: f))
+_cache_data = getattr(st, "cache_data", lambda **_: (lambda f: f))
+
+
+@_cache_resource()
 def get_duck_conn() -> duckdb.DuckDBPyConnection:
     """Return a cached DuckDB connection."""
     path = Path(DUCK_PATH)
@@ -18,7 +22,7 @@ def get_duck_conn() -> duckdb.DuckDBPyConnection:
     return duckdb.connect(str(path))
 
 
-@st.cache_data(ttl=300)
+@_cache_data(ttl=300)
 def read_duck(query: str) -> pd.DataFrame:
     """Execute ``query`` against the DuckDB connection and return a DataFrame."""
     conn = get_duck_conn()

--- a/ui/_state.py
+++ b/ui/_state.py
@@ -1,18 +1,38 @@
 """Centralized Streamlit session state keys and helpers."""
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 import streamlit as st
 
-# Default path to DuckDB database used across the UI
-DUCK_PATH = "data/processed/football.duckdb"
 
-# Common session keys
+# -----------------------------------------------------------------------------
+# Paths and session state defaults
+# -----------------------------------------------------------------------------
+
+# Resolve a single DATA_ROOT for the whole UI
+_DATA_ROOT = (
+    os.environ.get("DATA_ROOT")
+    or st.secrets.get("DATA_ROOT", "data")
+)
+
+# Default path to DuckDB database used across the UI
+DUCK_PATH = str(Path(_DATA_ROOT) / "processed" / "football.duckdb")
+
+
 def init_defaults() -> None:
     """Ensure expected keys exist in ``st.session_state``."""
-    if "selected_bets" not in st.session_state:
-        st.session_state["selected_bets"] = []
-    if "last_run_id" not in st.session_state:
-        st.session_state["last_run_id"] = None
+    st.session_state.setdefault("DATA_ROOT", _DATA_ROOT)
+    st.session_state.setdefault("raw_paths", {})
+    st.session_state.setdefault(
+        "processed_paths",
+        {"matches": DUCK_PATH, "odds_1x2_pre": DUCK_PATH, "market_probs_pre": DUCK_PATH},
+    )
+    st.session_state.setdefault("selected_bets", [])
+    st.session_state.setdefault("last_run_id", None)
+    st.session_state.setdefault("mlflow_run_id", None)
+    st.session_state.setdefault("artifacts_root", None)
 
 
 def get(key: str, default=None):


### PR DESCRIPTION
## Summary
- Centralize `DATA_ROOT` and track raw/processed paths in `st.session_state`
- Run diagnostics on real DataFrames and log ECE/Brier/KS-p/Regimes to MLflow
- Backtest UI reads artifacts and metrics from current MLflow run with debug listings

## Testing
- `pytest tests/test_backtest_artifacts_display.py tests/test_backtest_mlflow_wiring.py tests/test_ui_wiring.py::test_backtest_calls_engine` *(fails: AssertionError in test_backtest_calls_engine)*


------
https://chatgpt.com/codex/tasks/task_e_68bffb2a1724832b99abb05d72fe883d