### PR TITLE
Add market probability pipeline with calibration

### DIFF
--- a/engine/market/calibrate.py
+++ b/engine/market/calibrate.py
@@ -1,6 +1,87 @@
-"""Calibration utilities (stub)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy.stats import kstest
+from sklearn.isotonic import IsotonicRegression
+from sklearn.linear_model import LogisticRegression
 
 
-def no_calibration(probs):
-    """Return probabilities unchanged."""
-    return probs
+@dataclass
+class Calibrator:
+    method: str
+    models: dict[str, object]
+
+
+def fit_calibrator(df_train: pd.DataFrame, method: str = "isotonic") -> Calibrator:
+    """Fit a probability calibrator on the training set."""
+    outcome_idx = df_train["result"].map({"1": 0, "x": 1, "2": 2}).values
+    probs = df_train[["p1", "px", "p2"]].to_numpy()
+
+    calibrators: dict[str, object] = {}
+    for i, key in enumerate(["p1", "px", "p2"]):
+        X = probs[:, i]
+        y = (outcome_idx == i).astype(int)
+        if method == "platt":
+            model = LogisticRegression(max_iter=1000)
+            model.fit(X.reshape(-1, 1), y)
+        else:
+            model = IsotonicRegression(out_of_bounds="clip")
+            model.fit(X, y)
+        calibrators[key] = model
+    return Calibrator(method=method, models=calibrators)
+
+
+def apply_calibrator(df: pd.DataFrame, cal: Calibrator) -> pd.DataFrame:
+    """Apply a trained calibrator to a DataFrame of probabilities."""
+    df = df.copy()
+    for key in ["p1", "px", "p2"]:
+        model = cal.models[key]
+        X = df[key].to_numpy()
+        if cal.method == "platt":
+            df[key] = model.predict_proba(X.reshape(-1, 1))[:, 1]
+        else:
+            df[key] = model.predict(X)
+    total = df[["p1", "px", "p2"]].sum(axis=1)
+    df[["p1", "px", "p2"]] = df[["p1", "px", "p2"]].div(total, axis=0)
+    return df
+
+
+def calibration_report(df: pd.DataFrame) -> dict[str, float]:
+    """Compute calibration metrics on a probability DataFrame."""
+    probs = df[["p1", "px", "p2"]].to_numpy()
+    outcome_idx = df["result"].map({"1": 0, "x": 1, "2": 2}).to_numpy()
+    n = len(df)
+
+    labels = np.zeros_like(probs)
+    labels[np.arange(n), outcome_idx] = 1
+
+    brier = float(np.mean(np.sum((probs - labels) ** 2, axis=1)))
+
+    probs_flat = probs.ravel()
+    labels_flat = labels.ravel()
+    ece = _ece(probs_flat, labels_flat)
+
+    actual_probs = probs[np.arange(n), outcome_idx]
+    ks_p = float(kstest(actual_probs, "uniform").pvalue)
+
+    return {"ece": ece, "brier": brier, "ks_p": ks_p}
+
+
+def _ece(probs: np.ndarray, labels: np.ndarray, n_bins: int = 10) -> float:
+    bins = np.linspace(0.0, 1.0, n_bins + 1)
+    idx = np.digitize(probs, bins) - 1
+    ece = 0.0
+    total = len(probs)
+    for i in range(n_bins):
+        mask = idx == i
+        if not np.any(mask):
+            continue
+        bin_prob = probs[mask]
+        bin_labels = labels[mask]
+        acc = bin_labels.mean()
+        conf = bin_prob.mean()
+        ece += np.abs(acc - conf) * (mask.sum() / total)
+    return float(ece)

--- a/engine/market/odds.py
+++ b/engine/market/odds.py
@@ -1,6 +1,26 @@
-"""Market odds utilities (stub)."""
+from __future__ import annotations
+
+import pandas as pd
 
 
-def implied_probabilities(odds):
-    """Convert decimal odds to implied probabilities."""
-    return 1 / odds
+def implied_probs(df: pd.DataFrame) -> pd.DataFrame:
+    """Compute implied probabilities from decimal odds.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing columns ``odds_1``, ``odds_x`` and ``odds_2``.
+    """
+    df = df.copy()
+    df["p1"] = 1 / df["odds_1"]
+    df["px"] = 1 / df["odds_x"]
+    df["p2"] = 1 / df["odds_2"]
+    return df
+
+
+def remove_vig(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove the bookmaker's margin by normalising probabilities."""
+    df = df.copy()
+    total = df[["p1", "px", "p2"]].sum(axis=1)
+    df[["p1", "px", "p2"]] = df[["p1", "px", "p2"]].div(total, axis=0)
+    return df

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+import pandas as pd
+import numpy as np
+
 from engine.data.loader import unify
 from engine.io import persist
+from engine.market import calibrate, odds
 
 ROOT = Path(__file__).resolve().parent.parent
 PROCESSED_DIR = ROOT / "data" / "processed"
@@ -21,17 +25,84 @@ def build_canonical(div: str, seasons: list[str] | None = None) -> Path:
     return out_path
 
 
+def build_market(
+    div: str,
+    train_ratio: float = 0.8,
+    train_until: str | None = None,
+    calibrate_flag: bool = True,
+) -> None:
+    matches_path = PROCESSED_DIR / div / "matches.parquet"
+    if not matches_path.exists():
+        build_canonical(div)
+    df = persist.load_df(matches_path)
+    df["date"] = pd.to_datetime(df["date"])
+    home = df["ft_home_goals"].to_numpy(dtype=float)
+    away = df["ft_away_goals"].to_numpy(dtype=float)
+    result = np.where(home > away, "1", np.where(home < away, "2", "x"))
+    mask_missing = np.isnan(home) | np.isnan(away)
+    result = pd.Series(result)
+    result[mask_missing] = np.nan
+    df["result"] = result
+    df = df.dropna(subset=["result"])
+    df_probs = odds.implied_probs(df)
+    df_probs = odds.remove_vig(df_probs)
+    df_probs = df_probs.dropna(subset=["p1", "px", "p2"])
+
+    df_probs = df_probs.sort_values("date").reset_index(drop=True)
+    if train_until:
+        split_date = pd.to_datetime(train_until)
+        train_mask = df_probs["date"] <= split_date
+        df_train = df_probs[train_mask]
+        df_test = df_probs[~train_mask]
+    else:
+        split_idx = int(len(df_probs) * train_ratio)
+        df_train = df_probs.iloc[:split_idx]
+        df_test = df_probs.iloc[split_idx:]
+    splits = {
+        "train_until": df_train["date"].max().date().isoformat() if not df_train.empty else None,
+        "test_from": df_test["date"].min().date().isoformat() if not df_test.empty else None,
+        "n_train": int(len(df_train)),
+        "n_test": int(len(df_test)),
+    }
+
+    out_dir = PROCESSED_DIR / div
+    persist.save_json(splits, out_dir / "splits.json")
+
+    if calibrate_flag and not df_train.empty:
+        cal = calibrate.fit_calibrator(df_train)
+        df_probs = calibrate.apply_calibrator(df_probs, cal)
+        df_train_cal = calibrate.apply_calibrator(df_train, cal)
+        report = calibrate.calibration_report(df_train_cal)
+        persist.save_json(report, out_dir / "calibration_report.json")
+        print(f"Train ECE: {report['ece']:.6f}")
+        print(f"Train Brier: {report['brier']:.6f}")
+        print(f"Train KS p-value: {report['ks_p']:.6f}")
+
+    persist.save_df(df_probs[["date", "home", "away", "p1", "px", "p2"]], out_dir / "probs.parquet")
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="BettingEdge pipeline")
     parser.add_argument("--rebuild-canonical", action="store_true")
+    parser.add_argument("--build-market", action="store_true")
     parser.add_argument("--div", required=True)
     parser.add_argument("--seasons", nargs="*", default=[])
+    parser.add_argument("--train-ratio", type=float, default=0.8)
+    parser.add_argument("--train-until")
+    parser.add_argument("--calibrate", action=argparse.BooleanOptionalAction, default=True)
     args = parser.parse_args(argv)
 
     seasons = None if not args.seasons or args.seasons == ["all"] else args.seasons
 
     if args.rebuild_canonical:
         build_canonical(args.div, seasons)
+    elif args.build_market:
+        build_market(
+            args.div,
+            train_ratio=args.train_ratio,
+            train_until=args.train_until,
+            calibrate_flag=args.calibrate,
+        )
     else:
         parser.error("No action specified")
 


### PR DESCRIPTION
## Summary
- compute implied probabilities and remove bookmaker vig
- add calibrator utilities for isotonic or Platt scaling with calibration metrics
- extend pipeline to build market probabilities with train/test splits and optional calibration

## Testing
- `pytest`
- `python -m engine.pipeline --build-market --div I1 --train-ratio 0.8 --calibrate`

------
https://chatgpt.com/codex/tasks/task_e_68c00a415438832baaa790d151c1209e