### PR TITLE
Implement value signals, sizing, backtest simulation and run management

### DIFF
--- a/engine/backtest/simulate.py
+++ b/engine/backtest/simulate.py
@@ -1,6 +1,100 @@
-"""Backtest simulation stub."""
+"""Simple backtest simulator."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
 
 
-def run(df):
-    """Placeholder backtest that returns the input DataFrame."""
-    return df
+def run(
+    signals: pd.DataFrame,
+    bankroll: float = 1.0,
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, float]]:
+    """Run a sequential betting simulation.
+
+    Parameters
+    ----------
+    signals:
+        DataFrame with at least the columns ``date``, ``home``, ``away``,
+        ``selection``, ``odds``, ``stake`` and ``result``.
+    bankroll:
+        Starting bankroll. Defaults to 1 unit.
+    """
+
+    if signals.empty:
+        equity_df = pd.DataFrame(columns=["date", "equity"])
+        trades_df = pd.DataFrame(
+            columns=[
+                "date",
+                "match",
+                "selection",
+                "odds",
+                "stake",
+                "result",
+                "pnl",
+                "equity",
+            ]
+        )
+        metrics = {
+            "cagr": 0.0,
+            "maxdd": 0.0,
+            "sharpe": 0.0,
+            "hit_rate": 0.0,
+            "turnover": 0.0,
+        }
+        return equity_df, trades_df, metrics
+
+    df = signals.sort_values("date").reset_index(drop=True)
+
+    equity = bankroll
+    equity_rows = []
+    trade_rows = []
+
+    for _, row in df.iterrows():
+        hit = row["result"] == row["selection"]
+        pnl = row["stake"] * (row["odds"] - 1) if hit else -row["stake"]
+        equity += pnl
+
+        equity_rows.append({"date": row["date"], "equity": equity})
+        trade_rows.append(
+            {
+                "date": row["date"],
+                "match": f"{row['home']} vs {row['away']}",
+                "selection": row["selection"],
+                "odds": row["odds"],
+                "stake": row["stake"],
+                "result": int(hit),
+                "pnl": pnl,
+                "equity": equity,
+            }
+        )
+
+    equity_df = pd.DataFrame(equity_rows).sort_values("date").reset_index(drop=True)
+    trades_df = pd.DataFrame(trade_rows).reset_index(drop=True)
+
+    days = (equity_df["date"].iloc[-1] - equity_df["date"].iloc[0]).days or 1
+    cagr = (equity_df["equity"].iloc[-1] / bankroll) ** (365 / days) - 1
+    cummax = equity_df["equity"].cummax()
+    maxdd = float((equity_df["equity"] / cummax - 1).min())
+
+    returns = trades_df["pnl"] / trades_df["stake"].replace(0, np.nan)
+    sharpe = 0.0
+    if returns.count() > 1 and returns.std(ddof=1) > 0:
+        sharpe = float(returns.mean() / returns.std(ddof=1) * np.sqrt(len(returns)))
+
+    hit_rate = float(trades_df["result"].mean()) if not trades_df.empty else 0.0
+    turnover = float(trades_df["stake"].sum())
+
+    metrics = {
+        "cagr": float(cagr),
+        "maxdd": maxdd,
+        "sharpe": sharpe,
+        "hit_rate": hit_rate,
+        "turnover": turnover,
+    }
+
+    return equity_df, trades_df, metrics
+
+
+__all__ = ["run"]
+

--- a/engine/io/__init__.py
+++ b/engine/io/__init__.py
@@ -1,4 +1,4 @@
 """IO helpers for BettingEdge."""
 
 from .persist import ensure_dir, save_df, load_df, save_json, load_json  # noqa: F401
-from .runs import new_run_dir  # noqa: F401
+from .runs import create_run_dir, finalize_run  # noqa: F401

--- a/engine/io/runs.py
+++ b/engine/io/runs.py
@@ -3,11 +3,81 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 
+import pandas as pd
+import yaml
 
-def new_run_dir(base: str | Path, div: str) -> Path:
-    """Create a new run directory under ``base/div`` with a timestamp."""
-    base_path = Path(base)
+from . import persist
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNS_DIR = ROOT / "runs"
+
+
+def create_run_dir(div: str, base: str | Path | None = None) -> Path:
+    """Create a new run directory ``runs/div/run_YYYY-MM-DD_HH-MM-SS``."""
+
+    base_path = Path(base) if base is not None else RUNS_DIR
     timestamp = datetime.now().strftime("run_%Y-%m-%d_%H-%M-%S")
     run_path = base_path / div / timestamp
     run_path.mkdir(parents=True, exist_ok=True)
     return run_path
+
+
+def finalize_run(
+    run_dir: Path,
+    config: dict,
+    metrics: dict,
+    equity_df: pd.DataFrame,
+    trades_df: pd.DataFrame,
+) -> None:
+    """Persist results and update the division index."""
+
+    persist.save_df(equity_df, run_dir / "equity.csv")
+    persist.save_df(trades_df, run_dir / "trades.csv")
+    persist.save_json(metrics, run_dir / "metrics.json")
+
+    with open(run_dir / "config.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump(config, fh, sort_keys=True)
+
+    summary = (
+        "# Run Summary\n"
+        f"Picks: {len(trades_df)}\n"
+        f"CAGR: {metrics.get('cagr', 0.0):.4f}\n"
+        f"MaxDD: {metrics.get('maxdd', 0.0):.4f}\n"
+        f"Sharpe: {metrics.get('sharpe', 0.0):.4f}\n"
+    )
+    (run_dir / "summary.md").write_text(summary, encoding="utf-8")
+
+    div_dir = run_dir.parent
+    index_path = div_dir / "index.csv"
+    if index_path.exists():
+        index_df = pd.read_csv(index_path)
+    else:
+        index_df = pd.DataFrame(
+            columns=[
+                "run_id",
+                "date",
+                "train_until",
+                "test_from",
+                "picks",
+                "cagr",
+                "maxdd",
+                "sharpe",
+            ]
+        )
+
+    new_row = {
+        "run_id": run_dir.name,
+        "date": datetime.now().isoformat(timespec="seconds"),
+        "train_until": config.get("train_until"),
+        "test_from": config.get("test_from"),
+        "picks": len(trades_df),
+        "cagr": metrics.get("cagr"),
+        "maxdd": metrics.get("maxdd"),
+        "sharpe": metrics.get("sharpe"),
+    }
+    index_df = pd.concat([index_df, pd.DataFrame([new_row])], ignore_index=True)
+    persist.save_df(index_df, index_path)
+
+
+__all__ = ["create_run_dir", "finalize_run"]
+

--- a/engine/signal/sizing.py
+++ b/engine/signal/sizing.py
@@ -1,6 +1,49 @@
-"""Bet sizing stubs."""
+"""Bet sizing utilities."""
+
+from __future__ import annotations
+
+import pandas as pd
 
 
-def flat_stake(bankroll, fraction=0.01):
-    """Simple flat stake sizing."""
-    return bankroll * fraction
+def size_positions(
+    signals: pd.DataFrame,
+    mode: str = "fixed",
+    fraction: float = 0.01,
+    bankroll: float = 1.0,
+) -> pd.DataFrame:
+    """Attach stake sizes to a signals DataFrame.
+
+    Parameters
+    ----------
+    signals:
+        DataFrame produced by :func:`engine.signal.value.make_signals`.
+    mode:
+        ``"fixed"`` uses a flat fraction of ``bankroll`` for every bet.
+        ``"kelly_f"`` applies a fractional Kelly criterion using ``fraction``
+        as the multiplier of the optimal Kelly fraction.
+    fraction:
+        Fraction of bankroll to wager. For ``kelly_f`` it represents the
+        fraction of the Kelly stake to use (e.g. ``0.25`` for 25% Kelly).
+    bankroll:
+        Current bankroll, defaults to 1 unit.
+    """
+
+    df = signals.copy()
+    if df.empty:
+        df["stake"] = []
+        return df
+
+    if mode == "fixed":
+        df["stake"] = bankroll * fraction
+    elif mode == "kelly_f":
+        kelly_fraction = df["edge"] / (df["odds"] - 1)
+        kelly_fraction = kelly_fraction.clip(lower=0)
+        df["stake"] = bankroll * fraction * kelly_fraction
+    else:
+        raise ValueError(f"Unknown sizing mode: {mode}")
+
+    return df
+
+
+__all__ = ["size_positions"]
+

--- a/engine/signal/value.py
+++ b/engine/signal/value.py
@@ -1,6 +1,123 @@
-"""Value signal stub."""
+"""Computation of value-based betting signals.
+
+This module provides utilities to compare model probabilities against the
+market and extract positive expected value opportunities.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+_SEL_MAP = {
+    "1": ("p1", "odds_1"),
+    "x": ("px", "odds_x"),
+    "2": ("p2", "odds_2"),
+}
 
 
-def compute_value(probs, odds):
-    """Return expected value for each outcome."""
+def compute_value(probs: pd.Series, odds: pd.Series) -> pd.Series:
+    """Return the expected value for each outcome.
+
+    Parameters
+    ----------
+    probs:
+        Model probabilities for the selection.
+    odds:
+        Corresponding decimal odds from the market.
+    """
+
     return probs * odds - 1
+
+
+def make_signals(
+    df_probs: pd.DataFrame,
+    ev_min: float = 0.0,
+    odds_min: float | None = None,
+    odds_max: float | None = None,
+    max_per_day: int | None = None,
+) -> pd.DataFrame:
+    """Create a long-form DataFrame of value signals.
+
+    Parameters
+    ----------
+    df_probs:
+        DataFrame with columns ``date``, ``home``, ``away``, ``result`` and
+        probability/odds columns for each selection.
+    ev_min:
+        Minimum expected value threshold. Only selections with ``edge`` greater
+        than or equal to ``ev_min`` are retained.
+    odds_min / odds_max:
+        Optional bounds on allowed odds.
+    max_per_day:
+        If given, limit the number of picks per date to the selections with the
+        highest edges.
+    """
+
+    df = df_probs.copy()
+    df["date"] = pd.to_datetime(df["date"])
+
+    records: list[pd.DataFrame] = []
+    for sel, (p_col, o_col) in _SEL_MAP.items():
+        p_model = df[p_col]
+        odds = df[o_col]
+        p_market = 1 / odds
+        edge = compute_value(p_model, odds)
+
+        mask = edge >= ev_min
+        if odds_min is not None:
+            mask &= odds >= odds_min
+        if odds_max is not None:
+            mask &= odds <= odds_max
+
+        subset = df.loc[mask, ["date", "home", "away", "result"]].copy()
+        subset["selection"] = sel
+        subset["odds"] = odds[mask]
+        subset["p_model"] = p_model[mask]
+        subset["p_market"] = p_market[mask]
+        subset["edge"] = edge[mask]
+        records.append(subset)
+
+    if not records:
+        return pd.DataFrame(
+            columns=[
+                "date",
+                "match_id",
+                "home",
+                "away",
+                "selection",
+                "odds",
+                "p_model",
+                "p_market",
+                "edge",
+                "result",
+            ]
+        )
+
+    signals = pd.concat(records, ignore_index=True)
+    signals.sort_values("date", inplace=True)
+
+    # Generate a simple match identifier based on ordering of matches
+    signals.insert(1, "match_id", signals.groupby(["date", "home", "away"]).ngroup())
+
+    if max_per_day is not None:
+        signals = (
+            signals.groupby("date", group_keys=False)
+            .apply(lambda x: x.nlargest(max_per_day, "edge"))
+            .reset_index(drop=True)
+        )
+
+    return signals[
+        [
+            "date",
+            "match_id",
+            "home",
+            "away",
+            "selection",
+            "odds",
+            "p_model",
+            "p_market",
+            "edge",
+            "result",
+        ]
+    ]
+


### PR DESCRIPTION
## Summary
- add value signal generation with edge computation and filtering
- implement bet sizing for fixed and fractional Kelly strategies
- create backtest simulator and run management utilities
- extend pipeline CLI to generate picks, size stakes, simulate and store runs

## Testing
- `python -m engine.pipeline --div I1 --train-ratio 0.8 --build-market --calibrate --picks --ev-min 0.02 --stake-mode kelly_f --stake-fraction 0.25 --save-run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c00b9354d4832bb9e438b5e19bab78