### PR TITLE
feat(model): team-strength Poisson + blended probs per 1X2 (con calibrazione opzionale)

### DIFF
--- a/engine/model/poisson.py
+++ b/engine/model/poisson.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+
+
+MAX_GOALS = 8
+
+
+def fit_team_rates(
+    df_matches: pd.DataFrame, max_iter: int = 100, tol: float = 1e-6
+) -> dict:
+    """Estimate team attack/defense strengths and home advantage.
+
+    Parameters
+    ----------
+    df_matches: DataFrame
+        Must contain ``home``, ``away``, ``ft_home_goals`` and ``ft_away_goals``.
+    max_iter: int
+        Maximum number of Newton iterations.
+    tol: float
+        Convergence tolerance.
+    """
+    teams = sorted(set(df_matches["home"]) | set(df_matches["away"]))
+    n = len(teams)
+    team_idx = {team: i for i, team in enumerate(teams)}
+
+    home_idx = df_matches["home"].map(team_idx).to_numpy()
+    away_idx = df_matches["away"].map(team_idx).to_numpy()
+    g_home = df_matches["ft_home_goals"].to_numpy(dtype=float)
+    g_away = df_matches["ft_away_goals"].to_numpy(dtype=float)
+
+    att = np.zeros(n, dtype=float)
+    deff = np.zeros(n, dtype=float)
+    home_adv = 0.0
+
+    for _ in range(max_iter):
+        lambda_home = np.exp(att[home_idx] + deff[away_idx] + home_adv)
+        lambda_away = np.exp(att[away_idx] + deff[home_idx])
+
+        grad_att = np.zeros(n, dtype=float)
+        hess_att = np.zeros(n, dtype=float)
+        grad_def = np.zeros(n, dtype=float)
+        hess_def = np.zeros(n, dtype=float)
+
+        np.add.at(grad_att, home_idx, g_home - lambda_home)
+        np.add.at(grad_att, away_idx, g_away - lambda_away)
+        np.add.at(hess_att, home_idx, -lambda_home)
+        np.add.at(hess_att, away_idx, -lambda_away)
+
+        np.add.at(grad_def, away_idx, g_home - lambda_home)
+        np.add.at(grad_def, home_idx, g_away - lambda_away)
+        np.add.at(hess_def, away_idx, -lambda_home)
+        np.add.at(hess_def, home_idx, -lambda_away)
+
+        grad_home = float(np.sum(g_home - lambda_home))
+        hess_home = float(-np.sum(lambda_home))
+
+        step_att = np.divide(
+            grad_att, hess_att, out=np.zeros_like(grad_att), where=hess_att != 0
+        )
+        step_def = np.divide(
+            grad_def, hess_def, out=np.zeros_like(grad_def), where=hess_def != 0
+        )
+        step_home = grad_home / hess_home if hess_home != 0 else 0.0
+
+        att -= step_att
+        deff -= step_def
+        home_adv -= step_home
+
+        att -= np.mean(att)
+        deff -= np.mean(deff)
+
+        if (
+            np.max(np.abs(step_att)) < tol
+            and np.max(np.abs(step_def)) < tol
+            and abs(step_home) < tol
+        ):
+            break
+
+    return {
+        "attack": {team: float(att[team_idx[team]]) for team in teams},
+        "defense": {team: float(deff[team_idx[team]]) for team in teams},
+        "home_adv": float(home_adv),
+    }
+
+
+def _poisson_pmf(lmbda: float, max_goals: int = MAX_GOALS) -> np.ndarray:
+    goals = np.arange(0, max_goals + 1)
+    fact = np.array([math.factorial(i) for i in goals], dtype=float)
+    return np.exp(-lmbda) * np.power(lmbda, goals) / fact
+
+
+def predict_match_probs(df_matches: pd.DataFrame, rates: dict) -> pd.DataFrame:
+    """Predict 1X2 probabilities for each match using Poisson convolution."""
+    teams_att = rates.get("attack", {})
+    teams_def = rates.get("defense", {})
+    home_adv = rates.get("home_adv", 0.0)
+
+    rows = []
+    for _, row in df_matches.iterrows():
+        att_home = teams_att.get(row["home"], 0.0)
+        def_home = teams_def.get(row["home"], 0.0)
+        att_away = teams_att.get(row["away"], 0.0)
+        def_away = teams_def.get(row["away"], 0.0)
+
+        lambda_home = math.exp(att_home + def_away + home_adv)
+        lambda_away = math.exp(att_away + def_home)
+
+        p_home = _poisson_pmf(lambda_home)
+        p_away = _poisson_pmf(lambda_away)
+        mat = np.outer(p_home, p_away)
+        total = mat.sum()
+        p1 = np.triu(mat, 1).sum() / total
+        px = np.trace(mat) / total
+        p2 = np.tril(mat, -1).sum() / total
+        rows.append({"p1": p1, "px": px, "p2": p2})
+
+    return pd.DataFrame(rows, index=df_matches.index)

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -9,6 +9,7 @@ import numpy as np
 from engine.data.loader import unify
 from engine.io import persist, runs
 from engine.market import calibrate, odds
+from engine.model import poisson
 from engine.signal import value, sizing
 from engine.backtest import simulate
 
@@ -32,7 +33,8 @@ def build_market(
     train_ratio: float = 0.8,
     train_until: str | None = None,
     calibrate_flag: bool = True,
-) -> None:
+    model_source: str = "market",
+) -> tuple[dict, dict]:
     matches_path = PROCESSED_DIR / div / "matches.parquet"
     if not matches_path.exists():
         build_canonical(div)
@@ -49,20 +51,39 @@ def build_market(
     df_probs = odds.implied_probs(df)
     df_probs = odds.remove_vig(df_probs)
     df_probs = df_probs.dropna(subset=["p1", "px", "p2"])
-
     df_probs = df_probs.sort_values("date").reset_index(drop=True)
+
     if train_until:
         split_date = pd.to_datetime(train_until)
         train_mask = df_probs["date"] <= split_date
-        df_train = df_probs[train_mask]
-        df_test = df_probs[~train_mask]
+        train_idx = train_mask.to_numpy()
     else:
         split_idx = int(len(df_probs) * train_ratio)
-        df_train = df_probs.iloc[:split_idx]
-        df_test = df_probs.iloc[split_idx:]
+        train_idx = np.zeros(len(df_probs), dtype=bool)
+        train_idx[:split_idx] = True
+
+    if model_source in {"poisson", "blend"}:
+        rates = poisson.fit_team_rates(
+            df_probs.loc[train_idx, ["home", "away", "ft_home_goals", "ft_away_goals"]]
+        )
+        df_poi = poisson.predict_match_probs(df_probs[["home", "away"]], rates)
+        if model_source == "poisson":
+            df_probs[["p1", "px", "p2"]] = df_poi[["p1", "px", "p2"]]
+        else:
+            blended = (
+                0.5 * df_probs[["p1", "px", "p2"]] + 0.5 * df_poi[["p1", "px", "p2"]]
+            )
+            df_probs[["p1", "px", "p2"]] = blended.div(blended.sum(axis=1), axis=0)
+
+    df_train = df_probs.loc[train_idx]
+    df_test = df_probs.loc[~train_idx]
     splits = {
-        "train_until": df_train["date"].max().date().isoformat() if not df_train.empty else None,
-        "test_from": df_test["date"].min().date().isoformat() if not df_test.empty else None,
+        "train_until": (
+            df_train["date"].max().date().isoformat() if not df_train.empty else None
+        ),
+        "test_from": (
+            df_test["date"].min().date().isoformat() if not df_test.empty else None
+        ),
         "n_train": int(len(df_train)),
         "n_test": int(len(df_test)),
     }
@@ -70,6 +91,7 @@ def build_market(
     out_dir = PROCESSED_DIR / div
     persist.save_json(splits, out_dir / "splits.json")
 
+    report: dict[str, float] = {}
     if calibrate_flag and not df_train.empty:
         cal = calibrate.fit_calibrator(df_train)
         df_probs = calibrate.apply_calibrator(df_probs, cal)
@@ -79,11 +101,15 @@ def build_market(
         print(f"Train ECE: {report['ece']:.6f}")
         print(f"Train Brier: {report['brier']:.6f}")
         print(f"Train KS p-value: {report['ks_p']:.6f}")
+    else:
+        persist.save_json(report, out_dir / "calibration_report.json")
 
     persist.save_df(
         df_probs[["date", "home", "away", "p1", "px", "p2"]],
         out_dir / "probs.parquet",
     )
+
+    return splits, report
 
 
 def generate_picks(
@@ -99,7 +125,9 @@ def generate_picks(
     matches_path = out_dir / "matches.parquet"
     probs_path = out_dir / "probs.parquet"
     if not matches_path.exists() or not probs_path.exists():
-        raise FileNotFoundError("Required data files not found. Run with --build-market first.")
+        raise FileNotFoundError(
+            "Required data files not found. Run with --build-market first."
+        )
 
     df_matches = persist.load_df(matches_path)
     df_probs = persist.load_df(probs_path)
@@ -145,12 +173,15 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--seasons", nargs="*", default=[])
     parser.add_argument("--train-ratio", type=float, default=0.8)
     parser.add_argument("--train-until")
-    parser.add_argument("--calibrate", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--calibrate", action=argparse.BooleanOptionalAction, default=True
+    )
+    parser.add_argument(
+        "--model-source", choices=["market", "poisson", "blend"], default="market"
+    )
     parser.add_argument("--picks", action="store_true")
     parser.add_argument("--ev-min", type=float, default=0.0)
-    parser.add_argument(
-        "--stake-mode", choices=["fixed", "kelly_f"], default="fixed"
-    )
+    parser.add_argument("--stake-mode", choices=["fixed", "kelly_f"], default="fixed")
     parser.add_argument("--stake-fraction", type=float, default=0.01)
     parser.add_argument("--save-run", action="store_true")
     args = parser.parse_args(argv)
@@ -167,6 +198,7 @@ def main(argv: list[str] | None = None) -> None:
             train_ratio=args.train_ratio,
             train_until=args.train_until,
             calibrate_flag=args.calibrate,
+            model_source=args.model_source,
         )
         action_performed = True
     if args.picks:

--- a/ui/app.py
+++ b/ui/app.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+
 ROOT = Path(__file__).resolve().parents[1]  # repo root (contains "engine/")
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+# ruff: noqa: E402
 
 import re
 from pathlib import Path
@@ -13,9 +16,9 @@ import numpy as np
 import pandas as pd
 import streamlit as st
 
+from engine import pipeline
 from engine.data import loader
 from engine.io import persist, runs
-from engine.market import calibrate, odds
 from engine.signal import sizing, value
 from engine.backtest import simulate
 
@@ -82,72 +85,26 @@ def render_data_panel() -> None:
             load_matches.clear()
 
         st.write(f"Righe: {len(df)}")
-        st.write(
-            f"Range date: {df['date'].min().date()} - {df['date'].max().date()}"
-        )
+        st.write(f"Range date: {df['date'].min().date()} - {df['date'].max().date()}")
         st.session_state["canon_ok"] = True
         st.session_state["matches_df"] = df
 
 
 def _build_market(
-    div: str, train_ratio: float, train_until: str | None, calibrate_flag: bool
+    div: str,
+    train_ratio: float,
+    train_until: str | None,
+    calibrate_flag: bool,
+    model_source: str,
 ) -> tuple[dict, dict]:
-    df = load_matches(div)
-    df["date"] = pd.to_datetime(df["date"])
-    home = df["ft_home_goals"].to_numpy(dtype=float)
-    away = df["ft_away_goals"].to_numpy(dtype=float)
-    result = np.where(home > away, "1", np.where(home < away, "2", "x"))
-    mask_missing = np.isnan(home) | np.isnan(away)
-    result = pd.Series(result)
-    result[mask_missing] = np.nan
-    df["result"] = result
-    df = df.dropna(subset=["result"])
-
-    df_probs = odds.implied_probs(df)
-    df_probs = odds.remove_vig(df_probs)
-    df_probs = df_probs.dropna(subset=["p1", "px", "p2"])
-    df_probs = df_probs.sort_values("date").reset_index(drop=True)
-
-    if train_until:
-        split_date = pd.to_datetime(train_until)
-        train_mask = df_probs["date"] <= split_date
-        df_train = df_probs[train_mask]
-        df_test = df_probs[~train_mask]
-    else:
-        split_idx = int(len(df_probs) * train_ratio)
-        df_train = df_probs.iloc[:split_idx]
-        df_test = df_probs.iloc[split_idx:]
-
-    splits = {
-        "train_until": df_train["date"].max().date().isoformat()
-        if not df_train.empty
-        else None,
-        "test_from": df_test["date"].min().date().isoformat()
-        if not df_test.empty
-        else None,
-        "n_train": int(len(df_train)),
-        "n_test": int(len(df_test)),
-    }
-
-    out_dir = PROCESSED_DIR / div
-    persist.save_json(splits, out_dir / "splits.json")
-
-    if calibrate_flag and not df_train.empty:
-        cal = calibrate.fit_calibrator(df_train)
-        df_probs = calibrate.apply_calibrator(df_probs, cal)
-        df_train_rep = calibrate.apply_calibrator(df_train, cal)
-    else:
-        df_train_rep = df_train
-
-    report = calibrate.calibration_report(df_train_rep) if not df_train.empty else {}
-    persist.save_json(report, out_dir / "calibration_report.json")
-
-    persist.save_df(
-        df_probs[["date", "home", "away", "p1", "px", "p2"]],
-        out_dir / "probs.parquet",
+    splits, report = pipeline.build_market(
+        div,
+        train_ratio=train_ratio,
+        train_until=train_until,
+        calibrate_flag=calibrate_flag,
+        model_source=model_source,
     )
     load_probs.clear()
-
     return splits, report
 
 
@@ -158,14 +115,22 @@ def render_market_panel() -> None:
 
     div = st.session_state.get("div", "I1")
     train_ratio = st.slider("Train ratio", 0.5, 0.95, 0.8, step=0.05)
-    train_until = st.text_input(
-        "Data split (YYYY-MM-DD, lascia vuoto per usare il ratio)", ""
-    ).strip() or None
+    train_until = (
+        st.text_input(
+            "Data split (YYYY-MM-DD, lascia vuoto per usare il ratio)", ""
+        ).strip()
+        or None
+    )
     calibrate_flag = st.checkbox("Calibra", value=True)
+    model_source = st.selectbox(
+        "Modello", ["market", "poisson", "blend(0.5)"], index=0
+    ).split("(")[0]
 
     if st.button("Ricostruisci probabilità"):
         with st.spinner("Elaborazione..."):
-            splits, report = _build_market(div, train_ratio, train_until, calibrate_flag)
+            splits, report = _build_market(
+                div, train_ratio, train_until, calibrate_flag, model_source
+            )
         st.session_state["market_ok"] = True
         st.session_state["split_ok"] = True
         st.session_state["splits"] = splits
@@ -269,4 +234,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
- add Poisson model estimating team attack/defense strengths and home advantage
- support market, poisson, or blended probability sources in pipeline and CLI
- expose model selection in Streamlit UI via select box

## Testing
- `python -m engine.pipeline --rebuild-canonical --div I1 --seasons all`
- `python -m engine.pipeline --build-market --div I1 --train-ratio 0.8 --calibrate`
- `python -m engine.pipeline --build-market --div I1 --train-ratio 0.8 --calibrate --model-source poisson`
- `python -m engine.pipeline --build-market --div I1 --train-ratio 0.8 --calibrate --model-source blend`
- `ruff check engine/model/poisson.py engine/pipeline.py ui/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c03793e304832b923a5f523e03befd