### PR TITLE
feat(eval): multi-market picks/backtest + staking invariato + export coerente

### DIFF
--- a/engine/model/poisson.py
+++ b/engine/model/poisson.py
@@ -116,6 +116,14 @@ def predict_match_probs(df_matches: pd.DataFrame, rates: dict) -> pd.DataFrame:
         p1 = np.triu(mat, 1).sum() / total
         px = np.trace(mat) / total
         p2 = np.tril(mat, -1).sum() / total
-        rows.append({"p1": p1, "px": px, "p2": p2})
+        rows.append(
+            {
+                "p1": p1,
+                "px": px,
+                "p2": p2,
+                "lambda_home": lambda_home,
+                "lambda_away": lambda_away,
+            }
+        )
 
     return pd.DataFrame(rows, index=df_matches.index)


### PR DESCRIPTION
## Summary
- extend Poisson model predictions to include goal rates
- generalize signal generation and simulation to multiple markets and save per-market results
- update UI to backtest and export equity/trades by market

## Testing
- `python -m engine.pipeline --rebuild-canonical --div I1 --seasons all`
- `python -m engine.pipeline --build-market --div I1 --train-ratio 0.8 --calibrate --model-source poisson`
- `python -m engine.pipeline --div I1 --picks --ev-min 0.02 --stake-mode fixed --stake-fraction 0.01`
- `python -m engine.pipeline --div I1 --picks --ev-min 0.02 --stake-mode fixed --stake-fraction 0.01 --markets 1x2 ou25 dnb`


------
https://chatgpt.com/codex/tasks/task_e_68c063d756e4832b8530f76c57d6a08e