### PR TITLE
chore: CLI flags, docs, smoke e consistenza export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
         run: python -m engine.pipeline --rebuild-canonical --div I1 --seasons all
       - name: Smoke test market
         run: python -m engine.pipeline --build-market --div I1 --train-ratio 0.8 --calibrate
+      - name: Smoke test multi-market picks
+        run: python -m engine.pipeline --picks --div I1 --markets 1x2 ou25 --ev-min 0.02 --stake-mode fixed --stake-fraction 0.01
+        continue-on-error: true
       - name: Quick backtest (optional)
         run: python -m engine.pipeline --ev-min 0.02 --stake-mode fixed --stake-fraction 0.01 --div I1
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ pip install -e .[dev]
 ```bash
 # build canonical dataset
 python -m engine.pipeline --rebuild-canonical --div I1 --seasons all
-# build market model
-python -m engine.pipeline --build-market --div I1 --train-ratio 0.8 --calibrate
+# build market model (using market implied probabilities)
+python -m engine.pipeline --build-market --div I1 --train-ratio 0.8 --calibrate --model-source market
+# generate picks for multiple markets
+python -m engine.pipeline --picks --div I1 --ev-min 0.02 --markets 1x2 ou25
 # optional quick backtest
-python -m engine.pipeline --ev-min 0.02 --stake-mode fixed --stake-fraction 0.01 --div I1
+python -m engine.pipeline --picks --div I1 --ev-min 0.02 --stake-mode fixed --stake-fraction 0.01
 # launch UI
 streamlit run ui/streamlit_app.py
 ```
@@ -33,6 +35,14 @@ data/
 scripts/     helper scripts
 runs/        experiment outputs (gitignored)
 ```
+
+## Supported markets
+
+- `1x2` – home/draw/away
+- `ou25` – over/under 2.5 goals
+- `dnb` – draw no bet
+- `dc` – double chance
+- `ah` – Asian handicap (quarter lines supported)
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- expose model and market flags with validation and persisted run config
- document setup, end-to-end flow and supported markets
- exercise multi-market pick generation in CI

## Testing
- `pytest -q`
- `python -m engine.pipeline --help`
- `python -m engine.pipeline --rebuild-canonical --div I1 --seasons 23_24`
- `python -m engine.pipeline --build-market --div I1 --train-ratio 0.8 --calibrate`
- `python -m engine.pipeline --picks --div I1 --markets 1x2 ou25 --ev-min 0.02`


------
https://chatgpt.com/codex/tasks/task_e_68c068e4e03c832b89fb4518235a32fe