### PR TITLE
feat: allow external match predictions and backtesting

### DIFF
--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -34,7 +34,7 @@ def build_market(
     train_until: str | None = None,
     calibrate_flag: bool = True,
     model_source: str = "market",
-) -> tuple[dict, dict]:
+) -> tuple[dict, dict, dict, calibrate.Calibrator | None]:
     matches_path = PROCESSED_DIR / div / "matches.parquet"
     if not matches_path.exists():
         build_canonical(div)
@@ -90,6 +90,7 @@ def build_market(
     persist.save_json(splits, out_dir / "splits.json")
 
     report: dict[str, float] = {}
+    cal: calibrate.Calibrator | None = None
     if calibrate_flag and not df_train.empty:
         cal = calibrate.fit_calibrator(df_train)
         df_probs = calibrate.apply_calibrator(df_probs, cal)
@@ -107,7 +108,7 @@ def build_market(
         out_dir / "probs.parquet",
     )
 
-    return splits, report
+    return splits, report, rates, cal
 
 
 def generate_picks(

--- a/ui/app.py
+++ b/ui/app.py
@@ -20,6 +20,8 @@ from engine.data import loader
 from engine.io import persist, runs
 from engine.signal import sizing, value
 from engine.backtest import simulate
+from engine.market import odds, calibrate
+from engine.model import poisson
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -61,6 +63,36 @@ def load_probs(div: str) -> pd.DataFrame:
     return persist.load_df(path)
 
 
+def _parse_uploaded_matches(file) -> pd.DataFrame:
+    df = pd.read_csv(file)
+    rename_map = {
+        "Div": "div",
+        "Date": "date",
+        "Time": "time",
+        "HomeTeam": "home",
+        "AwayTeam": "away",
+        "B365H": "odds_1",
+        "B365D": "odds_x",
+        "B365A": "odds_2",
+        "FTHG": "ft_home_goals",
+        "FTAG": "ft_away_goals",
+    }
+    df = df.rename(columns={k: v for k, v in rename_map.items() if k in df.columns})
+    if not {"odds_1", "odds_x", "odds_2"}.issubset(df.columns):
+        lower = {c.lower(): c for c in df.columns}
+        for suf, new in [("h", "odds_1"), ("d", "odds_x"), ("a", "odds_2")]:
+            if new in df.columns:
+                continue
+            match = next((orig for lc, orig in lower.items() if lc.endswith(suf)), None)
+            if match:
+                df = df.rename(columns={match: new})
+    df["date"] = pd.to_datetime(df["date"], dayfirst=True, errors="coerce")
+    for col in ["ft_home_goals", "ft_away_goals"]:
+        if col not in df.columns:
+            df[col] = pd.NA
+    return df
+
+
 def render_data_panel() -> None:
     divs = list_divisions()
     default_div = divs.index("I1") if "I1" in divs else 0
@@ -88,6 +120,12 @@ def render_data_panel() -> None:
         st.session_state["canon_ok"] = True
         st.session_state["matches_df"] = df
 
+    uploaded = st.file_uploader("Carica partite per il test (opzionale)")
+    if uploaded is not None:
+        df_up = _parse_uploaded_matches(uploaded)
+        st.session_state["uploaded_df"] = df_up
+        st.write(f"Partite caricate: {len(df_up)}")
+
 
 def _build_market(
     div: str,
@@ -95,8 +133,8 @@ def _build_market(
     train_until: str | None,
     calibrate_flag: bool,
     model_source: str,
-) -> tuple[dict, dict]:
-    splits, report = pipeline.build_market(
+) -> tuple[dict, dict, dict, calibrate.Calibrator | None]:
+    splits, report, rates, cal = pipeline.build_market(
         div,
         train_ratio=train_ratio,
         train_until=train_until,
@@ -104,7 +142,7 @@ def _build_market(
         model_source=model_source,
     )
     load_probs.clear()
-    return splits, report
+    return splits, report, rates, cal
 
 
 def render_market_panel() -> None:
@@ -113,13 +151,18 @@ def render_market_panel() -> None:
         return
 
     div = st.session_state.get("div", "I1")
-    train_ratio = st.slider("Train ratio", 0.5, 0.95, 0.8, step=0.05)
+    uploaded_df = st.session_state.get("uploaded_df")
+    disabled = uploaded_df is not None
+    train_ratio = st.slider("Train ratio", 0.5, 0.95, 0.8, step=0.05, disabled=disabled)
     train_until = (
         st.text_input(
-            "Data split (YYYY-MM-DD, lascia vuoto per usare il ratio)", ""
+            "Data split (YYYY-MM-DD, lascia vuoto per usare il ratio)", "", disabled=disabled
         ).strip()
         or None
     )
+    if disabled:
+        train_ratio = 1.0
+        train_until = None
     calibrate_flag = st.checkbox("Calibra", value=True)
     model_source = st.selectbox(
         "Modello", ["market", "poisson", "blend(0.5)"], index=0
@@ -127,7 +170,7 @@ def render_market_panel() -> None:
 
     if st.button("Ricostruisci probabilità"):
         with st.spinner("Elaborazione..."):
-            splits, report = _build_market(
+            splits, report, rates, cal = _build_market(
                 div, train_ratio, train_until, calibrate_flag, model_source
             )
         st.session_state["market_ok"] = True
@@ -135,6 +178,8 @@ def render_market_panel() -> None:
         st.session_state["splits"] = splits
         st.session_state["calibration_report"] = report
         st.session_state["model_source"] = model_source
+        st.session_state["rates"] = rates
+        st.session_state["calibrator"] = cal
         st.write(f"ECE: {report.get('ece', float('nan')):.6f}")
         st.write(f"Brier: {report.get('brier', float('nan')):.6f}")
 
@@ -146,21 +191,47 @@ def _generate_picks(
     stake_mode: str,
     stake_fraction: float,
     bankroll: float,
-) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, dict]]:
-    df_matches = load_matches(div)
-    df_probs = load_probs(div)
-    df = df_matches.merge(df_probs, on=["date", "home", "away"], how="inner")
-    df["date"] = pd.to_datetime(df["date"])
-
-    splits = st.session_state.get("splits", {})
-    test_from = splits.get("test_from")
-    if test_from:
-        df = df[df["date"] >= pd.to_datetime(test_from)]
+    df_external: pd.DataFrame | None = None,
+    rates: dict | None = None,
+    calibrator_obj: calibrate.Calibrator | None = None,
+    model_source: str | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, dict], pd.DataFrame]:
+    model_source = model_source or st.session_state.get("model_source", "market")
+    if df_external is None:
+        df_matches = load_matches(div)
+        df_probs = load_probs(div)
+        df = df_matches.merge(df_probs, on=["date", "home", "away"], how="inner")
+        df["date"] = pd.to_datetime(df["date"])
+        splits = st.session_state.get("splits", {})
+        test_from = splits.get("test_from")
+        if test_from:
+            df = df[df["date"] >= pd.to_datetime(test_from)]
+    else:
+        df = df_external.copy()
+        df["date"] = pd.to_datetime(df["date"])
+        df_probs = odds.implied_probs(df)
+        df_probs = odds.remove_vig(df_probs)
+        df_poi = poisson.predict_match_probs(df_probs[["home", "away"]], rates or {})
+        if model_source == "poisson":
+            df_probs[["p1", "px", "p2"]] = df_poi[["p1", "px", "p2"]]
+        elif model_source == "blend":
+            blended = 0.5 * df_probs[["p1", "px", "p2"]] + 0.5 * df_poi[["p1", "px", "p2"]]
+            df_probs[["p1", "px", "p2"]] = blended.div(blended.sum(axis=1), axis=0)
+        df_probs[["lambda_home", "lambda_away"]] = df_poi[["lambda_home", "lambda_away"]]
+        if calibrator_obj is not None:
+            df_probs = calibrate.apply_calibrator(df_probs, calibrator_obj)
+        df = df.merge(
+            df_probs[["p1", "px", "p2", "lambda_home", "lambda_away"]],
+            left_index=True,
+            right_index=True,
+        )
 
     equity_dfs: list[pd.DataFrame] = []
     trades_dfs: list[pd.DataFrame] = []
     metrics_by_market: dict[str, dict] = {}
-    model_source = st.session_state.get("model_source", "market")
+    signals = pd.DataFrame()
+
+    results_available = set(["ft_home_goals", "ft_away_goals"]).issubset(df.columns) and df[["ft_home_goals", "ft_away_goals"]].notna().all().all()
 
     for mkt in markets:
         sigs = value.make_signals(
@@ -172,23 +243,20 @@ def _generate_picks(
         sigs = sizing.size_positions(
             sigs, mode=stake_mode, fraction=stake_fraction, bankroll=bankroll
         )
-        eq_df, tr_df, met = simulate.run(sigs, bankroll=bankroll, market=mkt)
-        tr_df = tr_df.sort_values("date").reset_index(drop=True)
-        eq_from_trades = tr_df[["date"]].copy()
-        eq_from_trades["market"] = mkt
-        eq_from_trades["equity"] = bankroll + tr_df["pnl"].cumsum()
-        equity_dfs.append(eq_from_trades)
-        trades_dfs.append(tr_df)
-        metrics_by_market[mkt] = met
+        signals = pd.concat([signals, sigs], ignore_index=True)
+        if results_available:
+            eq_df, tr_df, met = simulate.run(sigs, bankroll=bankroll, market=mkt)
+            tr_df = tr_df.sort_values("date").reset_index(drop=True)
+            eq_from_trades = tr_df[["date"]].copy()
+            eq_from_trades["market"] = mkt
+            eq_from_trades["equity"] = bankroll + tr_df["pnl"].cumsum()
+            equity_dfs.append(eq_from_trades)
+            trades_dfs.append(tr_df)
+            metrics_by_market[mkt] = met
 
-    equity_df = (
-        pd.concat(equity_dfs, ignore_index=True) if equity_dfs else pd.DataFrame()
-    )
-    trades_df = (
-        pd.concat(trades_dfs, ignore_index=True) if trades_dfs else pd.DataFrame()
-    )
-    return equity_df, trades_df, metrics_by_market
-
+    equity_df = pd.concat(equity_dfs, ignore_index=True) if equity_dfs else pd.DataFrame()
+    trades_df = pd.concat(trades_dfs, ignore_index=True) if trades_dfs else pd.DataFrame()
+    return equity_df, trades_df, metrics_by_market, signals
 
 def render_backtest_panel() -> None:
     if not st.session_state.get("market_ok"):
@@ -205,15 +273,26 @@ def render_backtest_panel() -> None:
     )
 
     if st.button("Genera picks & Backtest"):
+        df_ext = st.session_state.get("uploaded_df")
         with st.spinner("Simulazione..."):
-            equity_df, trades_df, metrics = _generate_picks(
-                div, markets, ev_min, stake_mode, stake_fraction, bankroll
+            equity_df, trades_df, metrics, signals = _generate_picks(
+                div,
+                markets,
+                ev_min,
+                stake_mode,
+                stake_fraction,
+                bankroll,
+                df_external=df_ext,
+                rates=st.session_state.get("rates"),
+                calibrator_obj=st.session_state.get("calibrator"),
+                model_source=st.session_state.get("model_source"),
             )
         st.session_state.update(
             {
                 "equity_df": equity_df,
                 "trades_df": trades_df,
                 "metrics": metrics,
+                "signals": signals,
                 "picks_ok": True,
                 "ev_min": ev_min,
                 "stake_mode": stake_mode,
@@ -224,49 +303,77 @@ def render_backtest_panel() -> None:
         )
 
     if st.session_state.get("picks_ok"):
-        eq_df = st.session_state["equity_df"].sort_values("date")
-        eq_pivot = eq_df.pivot_table(
-            index="date",
-            columns="market",
-            values="equity",
-            aggfunc="last",
-        )
-        st.line_chart(eq_pivot)
-        st.dataframe(st.session_state["trades_df"])
-        st.write(pd.DataFrame(st.session_state["metrics"]).T)
-        csv_data = st.session_state["trades_df"].to_csv(index=False).encode("utf-8")
-        json_data = st.session_state["trades_df"].to_json(orient="records")
-        st.download_button("Export CSV", data=csv_data, file_name="trades.csv")
-        st.download_button("Export JSON", data=json_data, file_name="trades.json")
-
-        if st.button("Salva run"):
-            splits = st.session_state.get("splits", {})
-            run_dir = runs.create_run_dir(div)
-            config = {
-                "div": div,
-                "ev_min": st.session_state["ev_min"],
-                "stake_mode": st.session_state["stake_mode"],
-                "stake_fraction": st.session_state["stake_fraction"],
-                "bankroll": st.session_state["bankroll"],
-                "train_until": splits.get("train_until"),
-                "test_from": splits.get("test_from"),
-            }
-            persist.save_json(config, run_dir / "config.json")
-            metrics_df = pd.DataFrame(st.session_state["metrics"]).T
-            persist.save_df(metrics_df, run_dir / "metrics_by_market.csv")
-            for mkt in st.session_state["markets"]:
-                eq_m = st.session_state["equity_df"][
-                    st.session_state["equity_df"]["market"] == mkt
-                ]
-                tr_m = st.session_state["trades_df"][
-                    st.session_state["trades_df"]["market"] == mkt
-                ]
-                persist.save_df(eq_m, run_dir / f"equity_{mkt}.csv")
-                persist.save_df(tr_m, run_dir / f"trades_{mkt}.csv")
-                persist.save_json(
-                    st.session_state["metrics"][mkt], run_dir / f"metrics_{mkt}.json"
+        if st.session_state["trades_df"].empty:
+            st.dataframe(st.session_state["signals"])
+            res_file = st.file_uploader("Carica risultati finali")
+            if res_file is not None:
+                df_res = _parse_uploaded_matches(res_file)
+                with st.spinner("Backtest..."):
+                    equity_df, trades_df, metrics, signals = _generate_picks(
+                        div,
+                        st.session_state.get("markets", markets),
+                        ev_min,
+                        stake_mode,
+                        stake_fraction,
+                        bankroll,
+                        df_external=df_res,
+                        rates=st.session_state.get("rates"),
+                        calibrator_obj=st.session_state.get("calibrator"),
+                        model_source=st.session_state.get("model_source"),
+                    )
+                st.session_state.update(
+                    {
+                        "equity_df": equity_df,
+                        "trades_df": trades_df,
+                        "metrics": metrics,
+                        "signals": signals,
+                    }
                 )
-            st.success(f"Run salvato in {run_dir}")
+                st.rerun()
+        else:
+            eq_df = st.session_state["equity_df"].sort_values("date")
+            eq_pivot = eq_df.pivot_table(
+                index="date",
+                columns="market",
+                values="equity",
+                aggfunc="last",
+            )
+            st.line_chart(eq_pivot)
+            st.dataframe(st.session_state["trades_df"])
+            st.write(pd.DataFrame(st.session_state["metrics"]).T)
+            csv_data = st.session_state["trades_df"].to_csv(index=False).encode("utf-8")
+            json_data = st.session_state["trades_df"].to_json(orient="records")
+            st.download_button("Export CSV", data=csv_data, file_name="trades.csv")
+            st.download_button("Export JSON", data=json_data, file_name="trades.json")
+
+            if st.button("Salva run"):
+                splits = st.session_state.get("splits", {})
+                run_dir = runs.create_run_dir(div)
+                config = {
+                    "div": div,
+                    "ev_min": st.session_state["ev_min"],
+                    "stake_mode": st.session_state["stake_mode"],
+                    "stake_fraction": st.session_state["stake_fraction"],
+                    "bankroll": st.session_state["bankroll"],
+                    "train_until": splits.get("train_until"),
+                    "test_from": splits.get("test_from"),
+                }
+                persist.save_json(config, run_dir / "config.json")
+                metrics_df = pd.DataFrame(st.session_state["metrics"]).T
+                persist.save_df(metrics_df, run_dir / "metrics_by_market.csv")
+                for mkt in st.session_state["markets"]:
+                    eq_m = st.session_state["equity_df"][
+                        st.session_state["equity_df"]["market"] == mkt
+                    ]
+                    tr_m = st.session_state["trades_df"][
+                        st.session_state["trades_df"]["market"] == mkt
+                    ]
+                    persist.save_df(eq_m, run_dir / f"equity_{mkt}.csv")
+                    persist.save_df(tr_m, run_dir / f"trades_{mkt}.csv")
+                    persist.save_json(
+                        st.session_state["metrics"][mkt], run_dir / f"metrics_{mkt}.json"
+                    )
+                st.success(f"Run salvato in {run_dir}")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- support training on full canonical dataset and expose rates/calibrator
- enable uploading custom matches for prediction and backtesting
- add interactive workflow to upload results for backtest
- rerun backtest automatically after uploading final results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c14bce1a28832bacbcc7d7dae6ac6b