### PR TITLE
Replace CAGR metric with ROI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python -m engine.ingest.keys --check
 - **ECE** – expected calibration error
 - **Brier** – mean squared error between probabilities and outcomes
 - **KS-p** – Kolmogorov–Smirnov test p-value
-- **CAGR** – compound annual growth rate of equity
+- **ROI** – return on investment (profit divided by turnover)
 - **MaxDD** – maximum drawdown
 - **Sharpe** – mean return divided by its standard deviation
 

--- a/engine/backtest/simulate.py
+++ b/engine/backtest/simulate.py
@@ -21,7 +21,7 @@ def run(
             columns=["date", "match_id", "market", "selection", "odds", "stake", "pnl"]
         )
         metrics = {
-            "cagr": 0.0,
+            "roi": 0.0,
             "maxdd": 0.0,
             "sharpe": 0.0,
             "hit_rate": 0.0,
@@ -61,8 +61,6 @@ def run(
     equity_df = pd.DataFrame(equity_rows).sort_values("date").reset_index(drop=True)
     trades_df = pd.DataFrame(trade_rows).reset_index(drop=True)
 
-    days = (equity_df["date"].iloc[-1] - equity_df["date"].iloc[0]).days or 1
-    cagr = (equity_df["equity"].iloc[-1] / bankroll) ** (365 / days) - 1
     cummax = equity_df["equity"].cummax()
     maxdd = float((equity_df["equity"] / cummax - 1).min())
 
@@ -73,9 +71,11 @@ def run(
 
     hit_rate = float((returns > 0).mean()) if not trades_df.empty else 0.0
     turnover = float(trades_df["stake"].sum())
+    profit = float(equity_df["equity"].iloc[-1] - bankroll)
+    roi = profit / turnover if turnover else 0.0
 
     metrics = {
-        "cagr": float(cagr),
+        "roi": roi,
         "maxdd": maxdd,
         "sharpe": sharpe,
         "hit_rate": hit_rate,

--- a/engine/io/runs.py
+++ b/engine/io/runs.py
@@ -41,7 +41,7 @@ def finalize_run(
     summary = (
         "# Run Summary\n"
         f"Picks: {len(trades_df)}\n"
-        f"CAGR: {metrics.get('cagr', 0.0):.4f}\n"
+        f"ROI: {metrics.get('roi', 0.0):.4f}\n"
         f"MaxDD: {metrics.get('maxdd', 0.0):.4f}\n"
         f"Sharpe: {metrics.get('sharpe', 0.0):.4f}\n"
     )
@@ -59,7 +59,7 @@ def finalize_run(
                 "train_until",
                 "test_from",
                 "picks",
-                "cagr",
+                "roi",
                 "maxdd",
                 "sharpe",
             ]
@@ -71,7 +71,7 @@ def finalize_run(
         "train_until": config.get("train_until"),
         "test_from": config.get("test_from"),
         "picks": len(trades_df),
-        "cagr": metrics.get("cagr"),
+        "roi": metrics.get("roi"),
         "maxdd": metrics.get("maxdd"),
         "sharpe": metrics.get("sharpe"),
     }


### PR DESCRIPTION
## Summary
- compute return on investment (ROI) instead of CAGR in backtest metrics
- update run finalization and summary to show ROI and record it in index
- document ROI metric in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1555c7554832baf796c114c124d2b